### PR TITLE
Decision scope fixes

### DIFF
--- a/AEPEdgePersonalization.xcodeproj/xcshareddata/xcschemes/AEPEdgePersonalization.xcscheme
+++ b/AEPEdgePersonalization.xcodeproj/xcshareddata/xcschemes/AEPEdgePersonalization.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:AEPEdgePersonalization.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C88C5F9E261D6499003AE3DE"
+               BuildableName = "FunctionalTests.xctest"
+               BlueprintName = "FunctionalTests"
+               ReferencedContainer = "container:AEPEdgePersonalization.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,29 +1,24 @@
 PODS:
-  - AEPCore (3.1.0):
-    - AEPRulesEngine (= 1.0.0)
-    - AEPServices (= 3.1.0)
-  - AEPEdge (1.0.0):
-    - AEPCore
-  - AEPRulesEngine (1.0.0)
-  - AEPServices (3.1.0)
+  - AEPCore (3.1.3):
+    - AEPRulesEngine (= 1.0.1)
+    - AEPServices (= 3.1.3)
+  - AEPRulesEngine (1.0.1)
+  - AEPServices (3.1.3)
 
 DEPENDENCIES:
   - AEPCore
-  - AEPEdge
 
 SPEC REPOS:
   trunk:
     - AEPCore
-    - AEPEdge
     - AEPRulesEngine
     - AEPServices
 
 SPEC CHECKSUMS:
-  AEPCore: 026568b04d8c302ad801a6b4ed6ec3c160817ef6
-  AEPEdge: 90ccd6aa9901a79be123ddee03e038f0d1837508
-  AEPRulesEngine: 8bbc694fce6900cd33b2496c7d4b33ee2eeffc46
-  AEPServices: cc1ec2987185ab01d62f6d41be0bb94a1b892efb
+  AEPCore: 6ec14ec9b1ff45999ea53be112aba85522ad00c4
+  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
+  AEPServices: e032bfacfcb31f3a583b2aa1e87df5d427cca95d
 
-PODFILE CHECKSUM: 2ee8aa1215a622583a845502867017f707d0f1d0
+PODFILE CHECKSUM: e9e3105fd51b250703e827683bc7a08abef2dfeb
 
 COCOAPODS: 1.10.0

--- a/Sources/AEPEdgePersonalization/DecisionScope.swift
+++ b/Sources/AEPEdgePersonalization/DecisionScope.swift
@@ -31,12 +31,12 @@ public class DecisionScope: NSObject, Codable {
     ///
     /// This initializer creates a scope name by Base64 encoding the JSON string created using the provided data.
     ///
-    /// If `itemCount` > 1, JSON string is
-    ///
-    ///     {"activityId":#activityId,"placementId":#placementId,"itemCount":#itemCount}
-    /// otherwise,
+    /// If `itemCount` == 1, JSON string is
     ///
     ///     {"activityId":#activityId,"placementId":#placementId}
+    /// otherwise,
+    ///
+    ///     {"activityId":#activityId,"placementId":#placementId,"itemCount":#itemCount}
     /// - Parameters:
     ///   - activityId: unique activity identifier for the decisioning activity.
     ///   - placementId: unique placement identifier for the decisioning activity offer.
@@ -64,24 +64,48 @@ public class DecisionScope: NSObject, Codable {
                 return false
             }
 
-            guard let activityId = dictionary[PersonalizationConstants.ACTIVITY_ID] as? String,
-                  !activityId.isEmpty
-            else {
-                Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Activity Id is nil or empty.")
-                return false
-            }
+            if dictionary.keys.contains(PersonalizationConstants.XDM_ACTIVITY_ID) {
+                // Validate xdm:activityId, xdm:placementId and xdm:itemCount
+                guard let activityId = dictionary[PersonalizationConstants.XDM_ACTIVITY_ID] as? String,
+                      !activityId.isEmpty
+                else {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Activity Id is nil or empty.")
+                    return false
+                }
 
-            guard let placementId = dictionary[PersonalizationConstants.PLACEMENT_ID] as? String,
-                  !placementId.isEmpty
-            else {
-                Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Placement Id is nil or empty.")
-                return false
-            }
+                guard let placementId = dictionary[PersonalizationConstants.XDM_PLACEMENT_ID] as? String,
+                      !placementId.isEmpty
+                else {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Placement Id is nil or empty.")
+                    return false
+                }
 
-            let itemCount = dictionary[PersonalizationConstants.ITEM_COUNT] as? Int ?? 1
-            if itemCount == 0 {
-                Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! itemCount is 0.")
-                return false
+                let itemCount = dictionary[PersonalizationConstants.XDM_ITEM_COUNT] as? Int ?? 1
+                if itemCount == 0 {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! itemCount is 0.")
+                    return false
+                }
+            } else {
+                // Validate activityId, placementId and itemCount
+                guard let activityId = dictionary[PersonalizationConstants.ACTIVITY_ID] as? String,
+                      !activityId.isEmpty
+                else {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Activity Id is nil or empty.")
+                    return false
+                }
+
+                guard let placementId = dictionary[PersonalizationConstants.PLACEMENT_ID] as? String,
+                      !placementId.isEmpty
+                else {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! Placement Id is nil or empty.")
+                    return false
+                }
+
+                let itemCount = dictionary[PersonalizationConstants.ITEM_COUNT] as? Int ?? 1
+                if itemCount == 0 {
+                    Log.debug(label: PersonalizationConstants.LOG_TAG, "Invalid scope \(name)! itemCount is 0.")
+                    return false
+                }
             }
         }
         Log.trace(label: PersonalizationConstants.LOG_TAG, "Decision scope is valid.")

--- a/Sources/AEPEdgePersonalization/Personalization+PublicAPI.swift
+++ b/Sources/AEPEdgePersonalization/Personalization+PublicAPI.swift
@@ -90,11 +90,13 @@ public extension Personalization {
                 return
             }
 
-            guard let propositions: [Proposition] = responseEvent.getTypedData(for: PersonalizationConstants.EventDataKeys.PROPOSITIONS) else {
+            guard
+                let propositions: [DecisionScope: Proposition] = responseEvent.getTypedData(for: PersonalizationConstants.EventDataKeys.PROPOSITIONS)
+            else {
                 completion(nil, AEPError.unexpected)
                 return
             }
-            completion(propositions.toDictionary { DecisionScope(name: $0.scope) }, .none)
+            completion(propositions, .none)
         }
     }
 

--- a/Sources/AEPEdgePersonalization/PersonalizationConstants.swift
+++ b/Sources/AEPEdgePersonalization/PersonalizationConstants.swift
@@ -18,8 +18,11 @@ enum PersonalizationConstants {
 
     static let DECISION_SCOPE_NAME = "name"
     static let ACTIVITY_ID = "activityId"
+    static let XDM_ACTIVITY_ID = "xdm:activityId"
     static let PLACEMENT_ID = "placementId"
+    static let XDM_PLACEMENT_ID = "xdm:placementId"
     static let ITEM_COUNT = "itemCount"
+    static let XDM_ITEM_COUNT = "xdm:itemCount"
 
     static let ERROR_UNKNOWN = "unknown"
 

--- a/Sources/AEPEdgePersonalization/StringInterpolation+Personalization.swift
+++ b/Sources/AEPEdgePersonalization/StringInterpolation+Personalization.swift
@@ -16,10 +16,10 @@ import Foundation
 
 extension String.StringInterpolation {
     mutating func appendInterpolation(activityId: String, placementId: String, itemCount: UInt) {
-        if itemCount > 1 {
-            appendInterpolation("{\"activityId\":\"\(activityId)\",\"placementId\":\"\(placementId)\",\"itemCount\":\(itemCount)}")
-        } else {
+        if itemCount == 1 {
             appendInterpolation("{\"activityId\":\"\(activityId)\",\"placementId\":\"\(placementId)\"}")
+        } else {
+            appendInterpolation("{\"activityId\":\"\(activityId)\",\"placementId\":\"\(placementId)\",\"itemCount\":\(itemCount)}")
         }
     }
 }

--- a/Tests/AEPEdgePersonalizationTests/UnitTests/DecisionScopeTests.swift
+++ b/Tests/AEPEdgePersonalizationTests/UnitTests/DecisionScopeTests.swift
@@ -56,7 +56,7 @@ class DecisionScopeTests: XCTestCase {
         let decisionScope = DecisionScope(activityId: "xcore:offer-activity:1111111111111111",
                                           placementId: "xcore:offer-placement:1111111111111111",
                                           itemCount: 0)
-        XCTAssertEqual("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==", decisionScope.name)
+        XCTAssertEqual("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEiLCJpdGVtQ291bnQiOjB9", decisionScope.name)
     }
 
     func testIsValid_scopeWithValidName() {
@@ -98,7 +98,37 @@ class DecisionScopeTests: XCTestCase {
         let decisionScope = DecisionScope(activityId: "xcore:offer-activity:1111111111111111",
                                           placementId: "xcore:offer-placement:1111111111111111",
                                           itemCount: 0)
+        XCTAssertFalse(decisionScope.isValid)
+    }
+
+    func testIsValid_encodedScopeWithDefaultItemCount() {
+        let decisionScope = DecisionScope(name: "eyJ4ZG06YWN0aXZpdHlJZCI6Inhjb3JlOm9mZmVyLWFjdGl2aXR5OjExMTExMTExMTExMTExMTEiLCJ4ZG06cGxhY2VtZW50SWQiOiJ4Y29yZTpvZmZlci1wbGFjZW1lbnQ6MTExMTExMTExMTExMTExMSJ9")
         XCTAssertTrue(decisionScope.isValid)
+    }
+
+    func testIsValid_encodedScopeWithItemCount() {
+        let decisionScope = DecisionScope(name: "eyJ4ZG06YWN0aXZpdHlJZCI6Inhjb3JlOm9mZmVyLWFjdGl2aXR5OjExMTExMTExMTExMTExMTEiLCJ4ZG06cGxhY2VtZW50SWQiOiJ4Y29yZTpvZmZlci1wbGFjZW1lbnQ6MTExMTExMTExMTExMTExMSIsInhkbTppdGVtQ291bnQiOjEwMH0=")
+        XCTAssertTrue(decisionScope.isValid)
+    }
+
+    func testIsValid_encodedScopeWithEmptyActivityId() {
+        let decisionScope = DecisionScope(name: "eyJ4ZG06YWN0aXZpdHlJZCI6IiIsInhkbTpwbGFjZW1lbnRJZCI6Inhjb3JlOm9mZmVyLXBsYWNlbWVudDoxMTExMTExMTExMTExMTExIn0=")
+        XCTAssertFalse(decisionScope.isValid)
+    }
+
+    func testIsValid_encodedScopeWithEmptyPlacementId() {
+        let decisionScope = DecisionScope(name: "eyJ4ZG06YWN0aXZpdHlJZCI6Inhjb3JlOm9mZmVyLWFjdGl2aXR5OjExMTExMTExMTExMTExMTEiLCJ4ZG06cGxhY2VtZW50SWQiOiIifQ==")
+        XCTAssertFalse(decisionScope.isValid)
+    }
+
+    func testIsValid_encodedScopeWithZeroItemCount() {
+        let decisionScope = DecisionScope(name: "eyJ4ZG06YWN0aXZpdHlJZCI6Inhjb3JlOm9mZmVyLWFjdGl2aXR5OjExMTExMTExMTExMTExMTEiLCJ4ZG06cGxhY2VtZW50SWQiOiJ4Y29yZTpvZmZlci1wbGFjZW1lbnQ6MTExMTExMTExMTExMTExMSIsInhkbTppdGVtQ291bnQiOjB9")
+        XCTAssertFalse(decisionScope.isValid)
+    }
+
+    func testIsValid_invalidEncodedScope() {
+        let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInhkbTpwbGFjZW1lbnRJZCI6Inhjb3JlOm9mZmVyLXBsYWNlbWVudDoxMTExMTExMTExMTExMTExIiwieGRtOml0ZW1Db3VudCI6MH0=")
+        XCTAssertFalse(decisionScope.isValid)
     }
 
     func testIsEqual() {

--- a/Tests/AEPEdgePersonalizationTests/UnitTests/StringInterpolation+PersonalizationTests.swift
+++ b/Tests/AEPEdgePersonalizationTests/UnitTests/StringInterpolation+PersonalizationTests.swift
@@ -31,6 +31,6 @@ class StringInterpolation_PersonalizationTests: XCTestCase {
 
     func testAppendInterpolation_withZeroItemCount() {
         let message = "\(activityId: ACTIVITY_ID, placementId: PLACEMENT_ID, itemCount: 0)"
-        XCTAssertEqual("{\"activityId\":\"xcore:offer-activity:1111111111111111\",\"placementId\":\"xcore:offer-placement:1111111111111111\"}", message)
+        XCTAssertEqual("{\"activityId\":\"xcore:offer-activity:1111111111111111\",\"placementId\":\"xcore:offer-placement:1111111111111111\",\"itemCount\":0}", message)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pr includes a few bug fixes

- Fixed Decision Scope validation - activityId/ placementId/ itemCount can be present in the encoded scope with or without xdm: prefix
- Fixed issue with decoding proposition dictionary present in event data for getPropositions API
- itemCount 0 should not result in a valid decision scope.
- Added functional test target in project scheme 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
