### PR TITLE
Version dependency on Mobile Core/ Edge & other updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,19 +21,12 @@ let package = Package(
         .library(name: "AEPOptimize", targets: ["AEPOptimize"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", from: "3.2.0")
-        .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", from: "1.1.0")
-    ],
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "3.2.0"))
+        .package(url: "https://github.com/adobe/aepsdk-edge-ios.git", .upToNextMajor(from: "1.1.0"))
     ],
     targets: [
         .target(name: "AEPOptimize",
                 dependencies: ["AEPCore", "AEPEdge"],
-                path: "Sources/AEPOptimize"),
-        .testTarget(name: "UnitTests",
-                    dependencies: ["AEPOptimize"],
-                    path: "Tests/AEPOptimize/UnitTests"),
-	    .testTarget(name: "FunctionalTests",
-                    dependencies: ["AEPOptimize"],
-                    path: "Tests/AEPOptimize/FunctionalTests"),
+                path: "Sources/AEPOptimize")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Adobe Experience Platform Mobile Optimize SDK
+# Adobe Experience Platform Optimize Mobile SDK
 
 ## About this project
 
 The AEP Mobile Optimize SDK Extension provides APIs to enable real-time personalization workflows in Adobe Experience Platform SDKs using the Edge decisioning services. It depends on AEPCore and requires AEPEdge Extension to send personalization query Events to the Experience Edge network.
 
 ## Requirements
+
 - Xcode 11.0 (or newer)
 - Swift 5.1 (or newer)
 
@@ -38,19 +39,20 @@ To add the AEPOptimize Package to your application, from the Xcode menu select:
 
 `File > Swift Packages > Add Package Dependency...`
 
-Enter the URL for the AEPOptimize package repository: `https://github.com/adobe/aepsdk-optimize-ios.git`.
+Enter the URL for the AEPOptimize package repository: `https://github.com/adobe/aepsdk-optimize-ios.git`. Click Next.
 
-When prompted, make sure you change the branch to `main`.
+Specify the Version rule for the package options. Click Next and Finish.
 
 Alternatively, if your project has a `Package.swift` file, you can add AEPOptimize directly to your dependencies:
 
 ```
 dependencies: [
-    .package(url: "https://github.com/adobe/aepsdk-optimize-ios.git", .branch: "main"),
+    .package(url: "https://github.com/adobe/aepsdk-optimize-ios.git", .upToNextMajor(from: "1.0.0"))
+],
 targets: [
        .target(name: "YourTarget",
-                    dependencies: ["AEPOptimize"],
-              path: "your/path"),
+               dependencies: ["AEPOptimize"],
+               path: "your/path"),
     ]
 ]
 ```
@@ -80,6 +82,7 @@ make pod-update
 ~~~
 
 #### Open the project Xcode workspace
+
 To open the project workspace in Xcode, click on `AEPOptimize.xcworkspace` or run the following Makefile target from the project root directory:
 
 ~~~
@@ -95,7 +98,8 @@ make test
 ~~~
 
 ## Documentation
-TBD
+
+Check out the extension documentation [here](https://github.com/adobe/aepsdk-optimize-ios/Documentation/README.md).
 
 ## Related Projects
 

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -23,7 +23,7 @@ public extension Optimize {
     /// - Parameter xdm: Additional XDM-formatted data to be sent in the personalization request.
     /// - Parameter data: Additional free-form data to be sent in the personalization request.
     @objc(updatePropositions:withXdm:andData:)
-    static func updatePropositions(for decisionScopes: [DecisionScope], with xdm: [String: Any]?, and data: [String: Any]? = nil) {
+    static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil) {
         let flattenedDecisionScopes = decisionScopes
             .filter { $0.isValid }
             .compactMap { $0.asDictionary() }
@@ -110,10 +110,10 @@ public extension Optimize {
     /// This API registers a permanent callback which will be invoked whenever the Edge extension dispatches an Event handle,
     /// upon a personalization decisions response from the Experience Edge Network.
     ///
-    /// The personalization query requests can be triggered by the `updatePropositions(for:with:)` API,
+    /// The personalization query requests can be triggered by the `updatePropositions(for:withXdm:andData:)` API,
     /// Edge extension `sendEvent(experienceEvent:_:)` API or launch rules consequence.
     ///
-    /// - Parameter completion: The completion handler to be invoked with the decision propositions.
+    /// - Parameter action: The completion handler to be invoked with the decision propositions.
     @objc(onPropositionsUpdate:)
     static func onPropositionsUpdate(perform action: @escaping ([DecisionScope: Proposition]?) -> Void) {
         MobileCore.registerEventListener(type: EventType.optimize,

--- a/TestApps/AEPOptimizeDemoSwiftUI/OffersView.swift
+++ b/TestApps/AEPOptimizeDemoSwiftUI/OffersView.swift
@@ -160,8 +160,8 @@ struct OffersView: View {
                         htmlDecisionScope,
                         jsonDecisionScope,
                         targetScope
-                    ], with: ["xdmKey": "1234"],
-                        and: data)
+                    ], withXdm: ["xdmKey": "1234"],
+                       andData: data)
                 }
                 
                 CustomButtonView(buttonTitle: "Get Propositions") {

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -67,7 +67,7 @@ class OptimizePublicAPITests: XCTestCase {
         let decisionScope = DecisionScope(activityId: "xcore:offer-activity:1111111111111111",
                                           placementId: "xcore:offer-placement:1111111111111111")
 
-        Optimize.updatePropositions(for: [decisionScope], with: nil)
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -131,8 +131,8 @@ class OptimizePublicAPITests: XCTestCase {
                                           placementId: "xcore:offer-placement:1111111111111111")
 
         Optimize.updatePropositions(for: [decisionScope],
-                                    with: ["myXdmKey": "myXdmValue"] as [String: Any],
-                                    and: ["myKey": "myValue"] as [String: Any])
+                                    withXdm: ["myXdmKey": "myXdmValue"] as [String: Any],
+                                    andData: ["myKey": "myValue"] as [String: Any])
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -181,7 +181,7 @@ class OptimizePublicAPITests: XCTestCase {
                                            placementId: "xcore:offer-placement:1111111111111111")
         let decisionScope2 = DecisionScope(name: "myMbox")
 
-        Optimize.updatePropositions(for: [decisionScope1, decisionScope2], with: nil)
+        Optimize.updatePropositions(for: [decisionScope1, decisionScope2], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -204,7 +204,7 @@ class OptimizePublicAPITests: XCTestCase {
         }
 
         // test
-        Optimize.updatePropositions(for: [], with: nil)
+        Optimize.updatePropositions(for: [], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -229,7 +229,7 @@ class OptimizePublicAPITests: XCTestCase {
         // test
         let decisionScope = DecisionScope(name: "")
 
-        Optimize.updatePropositions(for: [decisionScope], with: nil)
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -254,7 +254,7 @@ class OptimizePublicAPITests: XCTestCase {
         // test
         let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoiIn0=")
 
-        Optimize.updatePropositions(for: [decisionScope], with: nil)
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)
@@ -298,7 +298,7 @@ class OptimizePublicAPITests: XCTestCase {
                                            placementId: "xcore:offer-placement:1111111111111111")
         let decisionScope2 = DecisionScope(name: "myMbox")
 
-        Optimize.updatePropositions(for: [decisionScope1, decisionScope2], with: nil)
+        Optimize.updatePropositions(for: [decisionScope1, decisionScope2], withXdm: nil)
 
         // verify
         wait(for: [expectation], timeout: 1)

--- a/scripts/test-SPM.sh
+++ b/scripts/test-SPM.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
 PROJECT_NAME=TestProject
@@ -29,9 +39,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: \"AEPCore\", url: \"https://github.com/adobe/aepsdk-core-ios.git\", .branch(\"main\")),
-        .package(name: \"AEPEdge\", url: \"https://github.com/adobe/aepsdk-edge-ios.git\", .branch(\"main\")),
-        .package(name: \"AEPEdgePersonalization\", path: \"../\"),
+        .package(name: \"AEPCore\", url: \"https://github.com/adobe/aepsdk-core-ios.git\", .upToNextMajor(from:\"3.2.0\")),
+        .package(name: \"AEPEdge\", url: \"https://github.com/adobe/aepsdk-edge-ios.git\", .upToNextMajor(from:\"1.1.0\")),
+        .package(name: \"AEPOptimize\", path: \"../\"),
     ],
     targets: [
         .target(
@@ -42,7 +52,7 @@ let package = Package(
                 .product(name: \"AEPLifecycle\", package: \"AEPCore\"),
                 .product(name: \"AEPSignal\", package: \"AEPCore\"),
                 .product(name: \"AEPEdge\", package: \"AEPEdge\"),
-                .product(name: \"AEPEdgePersonalization\", package: \"AEPEdgePersonalization\"),
+                .product(name: \"AEPOptimize\", package: \"AEPOptimize\"),
             ])
     ]
 )

--- a/scripts/test-podspec.sh
+++ b/scripts/test-podspec.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
 PROJECT_NAME=TestProject
@@ -23,7 +33,7 @@ target '$PROJECT_NAME' do
   pod 'AEPLifecycle'
   pod 'AEPSignal'
   pod 'AEPEdge'
-  pod 'AEPEdgePersonalization', :path => '../AEPEdgePersonalization.podspec'
+  pod 'AEPOptimize', :path => '../AEPOptimize.podspec'
 end
 " >>Podfile
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 set -e
 
 if which jq >/dev/null; then
@@ -15,13 +25,13 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 
 echo "Target version - ${BLUE}$1${NC}"
-echo "------------------AEPEdgePersonalization-------------------"
-PODSPEC_VERSION_IN_AEPEdgePersonalization=$(pod ipc spec AEPEdgePersonalization.podspec | jq '.version' | tr -d '"')
-echo "Local podspec version - ${BLUE}${PODSPEC_VERSION_IN_AEPEdgePersonalization}${NC}"
-SOURCE_CODE_VERSION_IN_AEPEdgePersonalization=$(cat ./Sources/AEPEdgePersonalization/PersonalizationConstants.swift | egrep '\s*EXTENSION_VERSION\s*=\s*\"(.*)\"' | ruby -e "puts gets.scan(/\"(.*)\"/)[0] " | tr -d '"')
-echo "Source code version - ${BLUE}${SOURCE_CODE_VERSION_IN_AEPEdgePersonalization}${NC}"
+echo "------------------AEPOptimize-------------------"
+PODSPEC_VERSION_IN_AEPOptimize=$(pod ipc spec AEPOptimize.podspec | jq '.version' | tr -d '"')
+echo "Local podspec version - ${BLUE}${PODSPEC_VERSION_IN_AEPOptimize}${NC}"
+SOURCE_CODE_VERSION_IN_AEPOptimize=$(cat ./Sources/AEPOptimize/OptimizeConstants.swift | egrep '\s*EXTENSION_VERSION\s*=\s*\"(.*)\"' | ruby -e "puts gets.scan(/\"(.*)\"/)[0] " | tr -d '"')
+echo "Source code version - ${BLUE}${SOURCE_CODE_VERSION_IN_AEPOptimize}${NC}"
 
-if [[ "$1" == "$PODSPEC_VERSION_IN_AEPEdgePersonalization" ]] && [[ "$1" == "$SOURCE_CODE_VERSION_IN_AEPEdgePersonalization" ]]; then
+if [[ "$1" == "$PODSPEC_VERSION_IN_AEPOptimize" ]] && [[ "$1" == "$SOURCE_CODE_VERSION_IN_AEPOptimize" ]]; then
     echo "${GREEN}Pass!${NC}"
 else
     echo "${RED}[Error]${NC} Versions do not match!"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Aligned with other extensions on using `.upToNextMajor(from: "x.x.x")` for version dependency on Mobile Core/ Edge.
- Updated Extension README for SPM integration.
- Updated licence header in Scripts.
- Fixed `updatePropositions` external parameters.
- Updated scripts `AEPEdgePersonalization` -> `AEPOptimize`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
