### PR TITLE
Use standardized EE - Event Types for Proposition Interaction Tracking

### DIFF
--- a/Documentation/PUBLIC_APIs.md
+++ b/Documentation/PUBLIC_APIs.md
@@ -8,7 +8,7 @@ This API reference guide provides usage information for the Optimize extension's
 - [extensionVersion](#extensionVersion)
 - [getPropositions](#getPropositions)
 - [onPropositionsUpdate](#onPropositionsUpdate)
-- [registerExtension](#registerExtension)
+- [registerExtensions](#registerExtensions)
 - [resetIdentities](#resetIdentities)
 - [updatePropositions](#updatePropositions)
 
@@ -129,7 +129,7 @@ Optimize.getPropositions(for: [decisionScope1, decisionScope2]) { propositionsDi
 
 ```objc
 + (void) getPropositions: (NSArray<AEPDecisionScope*>* _Nonnull) decisionScopes 
-              completion: (void (^)(NSDictionary<AEPDecisionScope*, AEPProposition*>* _Nullable propositionsDict, NSError* _Nullable error)) completion;
+              completion: (void (^ _Nonnull)(NSDictionary<AEPDecisionScope*, AEPProposition*>* _Nullable propositionsDict, NSError* _Nullable error)) completion;
 ```
 
 ##### Example
@@ -184,7 +184,7 @@ Optimize.onPropositionsUpdate { propositionsDict in
 ##### Syntax
 
 ```objc
-+ (void) onPropositionsUpdate: (void (^)(NSDictionary<AEPDecisionScope*, AEPProposition*>* _Nullable)) action;
++ (void) onPropositionsUpdate: (void (^ _Nonnull)(NSDictionary<AEPDecisionScope*, AEPProposition*>* _Nullable)) action;
 ```
 
 ##### Example
@@ -197,7 +197,7 @@ Optimize.onPropositionsUpdate { propositionsDict in
 
 ---
 
-### registerExtension
+### registerExtensions
 
 This `MobileCore` API can be invoked to register the Optimize extension.
 
@@ -224,7 +224,7 @@ MobileCore.registerExtensions([Optimize.self, ...]) {
 
 ```objc
 + (void) registerExtensions: (NSArray<Class*>* _Nonnull) extensions 
-                 completion: (void (^)(void)) completion;
+                 completion: (void (^ _Nullable)(void)) completion;
 ```
 
 ##### Example

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ make test
 
 ## Documentation
 
-Check out the extension documentation [here](https://github.com/adobe/aepsdk-optimize-ios/Documentation/README.md).
+Check out the [Documentation](./Documentation/README.md) directory to learn more about the Optimize extension.
 
 ## Related Projects
 

--- a/Sources/AEPOptimize/Offer+Tracking.swift
+++ b/Sources/AEPOptimize/Offer+Tracking.swift
@@ -15,27 +15,28 @@ import Foundation
 
 // MARK: Offer extension
 
+@objc
 public extension Offer {
     /// Creates a dictionary containing XDM formatted data for `Experience Event - Proposition Interactions` field group from the given proposition option.
     ///
     /// The Edge `sendEvent(experienceEvent:_:)` API can be used to dispatch this data in an Experience Event along with any additional XDM, free-form data, or override dataset identifier.
     ///
-    /// - Note: The returned XDM data also contains the `eventType` for the Experience Event with value `display`.
+    /// - Note: The returned XDM data also contains the `eventType` for the Experience Event with value `decisioning.propositionDisplay`.
     /// - Returns A dictionary containing XDM data for the propositon interactions.
     /// - SeeAlso: `interactionXdm(for:)`
     func generateDisplayInteractionXdm() -> [String: Any] {
-        generateInteractionXdm(for: OptimizeConstants.JsonValues.EXPERIENCE_EVENT_TYPE_DISPLAY)
+        generateInteractionXdm(for: OptimizeConstants.JsonValues.EE_EVENT_TYPE_PROPOSITION_DISPLAY)
     }
 
     /// Creates a dictionary containing XDM formatted data for `Experience Event - Proposition Interactions` field group from the given proposition option.
     ///
     /// The Edge `sendEvent(experienceEvent:_:)` API can be used to dispatch this data in an Experience Event along with any additional XDM, free-form data, or override dataset identifier.
     ///
-    /// - Note: The returned XDM data also contains the `eventType` for the Experience Event with value `click`.
+    /// - Note: The returned XDM data also contains the `eventType` for the Experience Event with value `decisioning.propositionInteract`.
     /// - Returns A dictionary containing XDM data for the propositon interactions.
     /// - SeeAlso: `interactionXdm(for:)`
     func generateTapInteractionXdm() -> [String: Any] {
-        generateInteractionXdm(for: OptimizeConstants.JsonValues.EXPERIENCE_EVENT_TYPE_CLICK)
+        generateInteractionXdm(for: OptimizeConstants.JsonValues.EE_EVENT_TYPE_PROPOSITION_INTERACT)
     }
 
     /// Dispatches an event for the Edge extension to send an Experience Event to the Edge network with the display interaction data for the given proposition item.

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -121,7 +121,7 @@ public class Optimize: NSObject, Extension {
 
         // Add xdm
         var xdmData: [String: Any] = [
-            OptimizeConstants.JsonKeys.EXPERIENCE_EVENT_TYPE: OptimizeConstants.JsonValues.EXPERIENCE_EVENT_TYPE_PERSONALIZATION
+            OptimizeConstants.JsonKeys.EXPERIENCE_EVENT_TYPE: OptimizeConstants.JsonValues.EE_EVENT_TYPE_PERSONALIZATION
         ]
         if let additionalXdmData = event.data?[OptimizeConstants.EventDataKeys.XDM] as? [String: Any] {
             xdmData.merge(additionalXdmData) { old, _ in old }

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -94,8 +94,8 @@ enum OptimizeConstants {
     }
 
     enum JsonValues {
-        static let EXPERIENCE_EVENT_TYPE_PERSONALIZATION = "personalization.request"
-        static let EXPERIENCE_EVENT_TYPE_DISPLAY = "display"
-        static let EXPERIENCE_EVENT_TYPE_CLICK = "click"
+        static let EE_EVENT_TYPE_PERSONALIZATION = "personalization.request"
+        static let EE_EVENT_TYPE_PROPOSITION_DISPLAY = "decisioning.propositionDisplay"
+        static let EE_EVENT_TYPE_PROPOSITION_INTERACT = "decisioning.propositionInteract"
     }
 }

--- a/Sources/AEPOptimize/Proposition+Tracking.swift
+++ b/Sources/AEPOptimize/Proposition+Tracking.swift
@@ -15,6 +15,7 @@ import Foundation
 
 // MARK: Proposition extension
 
+@objc
 public extension Proposition {
     /// Creates a dictionary containing XDM formatted data for `Experience Event - Proposition Reference` field group from the given proposition.
     ///

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -1024,7 +1024,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               data: [
                                 "requesttype": "trackpropositions",
                                 "propositioninteractions": [
-                                    "eventType": "display",
+                                    "eventType": "decisioning.propositionDisplay",
                                     "_experience": [
                                         "decisioning": [
                                             "propositions": [
@@ -1060,7 +1060,7 @@ class OptimizeFunctionalTests: XCTestCase {
 
         let xdm = try XCTUnwrap(dispatchedEvent.data?["xdm"] as? [String: Any])
         let eventType = try XCTUnwrap(xdm["eventType"] as? String)
-        XCTAssertEqual("display", eventType)
+        XCTAssertEqual("decisioning.propositionDisplay", eventType)
 
         let experience = try XCTUnwrap(xdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -1106,7 +1106,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               data: [
                                 "requesttype": "trackpropositions",
                                 "propositioninteractions": [
-                                    "eventType": "click",
+                                    "eventType": "decisioning.propositionInteract",
                                     "_experience": [
                                         "decisioning": [
                                             "propositions": [
@@ -1142,7 +1142,7 @@ class OptimizeFunctionalTests: XCTestCase {
 
         let xdm = try XCTUnwrap(dispatchedEvent.data?["xdm"] as? [String: Any])
         let eventType = try XCTUnwrap(xdm["eventType"] as? String)
-        XCTAssertEqual("click", eventType)
+        XCTAssertEqual("decisioning.propositionInteract", eventType)
 
         let experience = try XCTUnwrap(xdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -1187,7 +1187,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               data: [
                                 "requesttype": "trackpropositions",
                                 "propositioninteractions": [
-                                    "eventType": "click",
+                                    "eventType": "decisioning.propositionInteract",
                                     "_experience": [
                                         "decisioning": [
                                             "propositions": [
@@ -1225,7 +1225,7 @@ class OptimizeFunctionalTests: XCTestCase {
 
         let xdm = try XCTUnwrap(dispatchedEvent.data?["xdm"] as? [String: Any])
         let eventType = try XCTUnwrap(xdm["eventType"] as? String)
-        XCTAssertEqual("click", eventType)
+        XCTAssertEqual("decisioning.propositionInteract", eventType)
 
         let experience = try XCTUnwrap(xdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -1256,7 +1256,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               source: "com.adobe.eventSource.requestContent",
                               data: [
                                 "propositioninteractions": [
-                                    "eventType": "display",
+                                    "eventType": "decisioning.propositionDisplay",
                                     "_experience": [
                                         "decisioning": [
                                             "propositions": [
@@ -1295,7 +1295,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               data: [
                                 "requesttype": "trackpropositions",
                                 "propositioninteractions": [
-                                    "eventType": "display",
+                                    "eventType": "decisioning.propositionDisplay",
                                     "_experience": [
                                         "decisioning": [
                                             "propositions": [

--- a/Tests/AEPOptimizeTests/UnitTests/OfferTrackingTests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OfferTrackingTests.swift
@@ -49,7 +49,7 @@ extension PropositionTests {
 
         let propositionInteractionXdm = offer.generateDisplayInteractionXdm()
         let eventType = try XCTUnwrap(propositionInteractionXdm["eventType"] as? String)
-        XCTAssertEqual("display", eventType)
+        XCTAssertEqual("decisioning.propositionDisplay", eventType)
 
         let experience = try XCTUnwrap(propositionInteractionXdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -99,7 +99,7 @@ extension PropositionTests {
 
         let propositionInteractionXdm = offer.generateDisplayInteractionXdm()
         let eventType = try XCTUnwrap(propositionInteractionXdm["eventType"] as? String)
-        XCTAssertEqual("display", eventType)
+        XCTAssertEqual("decisioning.propositionDisplay", eventType)
 
         let experience = try XCTUnwrap(propositionInteractionXdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -141,7 +141,7 @@ extension PropositionTests {
 
         let propositionInteractionXdm = offer.generateTapInteractionXdm()
         let eventType = try XCTUnwrap(propositionInteractionXdm["eventType"] as? String)
-        XCTAssertEqual("click", eventType)
+        XCTAssertEqual("decisioning.propositionInteract", eventType)
 
         let experience = try XCTUnwrap(propositionInteractionXdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -191,7 +191,7 @@ extension PropositionTests {
 
         let propositionInteractionXdm = offer.generateTapInteractionXdm()
         let eventType = try XCTUnwrap(propositionInteractionXdm["eventType"] as? String)
-        XCTAssertEqual("click", eventType)
+        XCTAssertEqual("decisioning.propositionInteract", eventType)
 
         let experience = try XCTUnwrap(propositionInteractionXdm["_experience"] as? [String: Any])
         let decisioning = try XCTUnwrap(experience["decisioning"] as? [String: Any])
@@ -219,7 +219,7 @@ extension PropositionTests {
         let testEventData: [String: Any] = [
             "requesttype": "trackpropositions",
             "propositioninteractions": [
-                "eventType": "display",
+                "eventType": "decisioning.propositionDisplay",
                 "decisioning": [
                     "propositions": [
                         [
@@ -251,7 +251,7 @@ extension PropositionTests {
                 XCTAssertEqual("trackpropositions", event.data?["requesttype"] as? String)
 
                 let propositioninteractions = event.data?["propositioninteractions"] as? [String: Any]
-                XCTAssertEqual("display", propositioninteractions?["eventType"] as? String)
+                XCTAssertEqual("decisioning.propositionDisplay", propositioninteractions?["eventType"] as? String)
 
                 let experience = propositioninteractions?["_experience"] as? [String: Any]
                 let decisioning = experience?["decisioning"] as? [String: Any]
@@ -317,7 +317,7 @@ extension PropositionTests {
         let testEventData: [String: Any] = [
             "requesttype": "trackpropositions",
             "propositioninteractions": [
-                "eventType": "display",
+                "eventType": "decisioning.propositionDisplay",
                 "decisioning": [
                     "propositions": [
                         [
@@ -349,7 +349,7 @@ extension PropositionTests {
                 XCTAssertEqual("trackpropositions", event.data?["requesttype"] as? String)
 
                 let propositioninteractions = event.data?["propositioninteractions"] as? [String: Any]
-                XCTAssertEqual("display", propositioninteractions?["eventType"] as? String)
+                XCTAssertEqual("decisioning.propositionDisplay", propositioninteractions?["eventType"] as? String)
 
                 let experience = propositioninteractions?["_experience"] as? [String: Any]
                 let decisioning = experience?["decisioning"] as? [String: Any]
@@ -398,7 +398,7 @@ extension PropositionTests {
         let testEventData: [String: Any] = [
             "requesttype": "trackpropositions",
             "propositioninteractions": [
-                "eventType": "click",
+                "eventType": "decisioning.propositionInteract",
                 "decisioning": [
                     "propositions": [
                         [
@@ -430,7 +430,7 @@ extension PropositionTests {
                 XCTAssertEqual("trackpropositions", event.data?["requesttype"] as? String)
 
                 let propositioninteractions = event.data?["propositioninteractions"] as? [String: Any]
-                XCTAssertEqual("click", propositioninteractions?["eventType"] as? String)
+                XCTAssertEqual("decisioning.propositionInteract", propositioninteractions?["eventType"] as? String)
 
                 let experience = propositioninteractions?["_experience"] as? [String: Any]
                 let decisioning = experience?["decisioning"] as? [String: Any]
@@ -496,7 +496,7 @@ extension PropositionTests {
         let testEventData: [String: Any] = [
             "requesttype": "trackpropositions",
             "propositioninteractions": [
-                "eventType": "click",
+                "eventType": "decisioning.propositionInteract",
                 "decisioning": [
                     "propositions": [
                         [
@@ -528,7 +528,7 @@ extension PropositionTests {
                 XCTAssertEqual("trackpropositions", event.data?["requesttype"] as? String)
 
                 let propositioninteractions = event.data?["propositioninteractions"] as? [String: Any]
-                XCTAssertEqual("click", propositioninteractions?["eventType"] as? String)
+                XCTAssertEqual("decisioning.propositionInteract", propositioninteractions?["eventType"] as? String)
 
                 let experience = propositioninteractions?["_experience"] as? [String: Any]
                 let decisioning = experience?["decisioning"] as? [String: Any]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ref:[MOB-14761]
- Using standardized event types from EE eventType meta:enum for proposition interactions
```
decisioning.propositionDisplay
decisioning.propositionInteract
```
- Updated API docs with minor syntax fixes
-  Using `objc` annotation for Proposition and Offer extension 
- Fixed documentation link in extension README.md

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
