### PR TITLE
add an app extension for compilation verification and set required ap…

### DIFF
--- a/AEPOptimize.xcodeproj/project.pbxproj
+++ b/AEPOptimize.xcodeproj/project.pbxproj
@@ -8,8 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		048957B1B953F5E65058436F /* Pods_AEPOptimize.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6530E7CDA75EFA93DD6318C /* Pods_AEPOptimize.framework */; };
+		25A7F16F9547EE83F5734E3C /* Pods_shared_AEPOptimizeDemoAppExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9756675167E8274119439EC8 /* Pods_shared_AEPOptimizeDemoAppExtension.framework */; };
 		3AEB05F692581AAC67BB2B85 /* Pods_FunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EE07424FC1DD074D8B9FD0C /* Pods_FunctionalTests.framework */; };
 		41CB4F5069B6936944DDB6B1 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74B9C2F3CA52295A7E3D1705 /* Pods_UnitTests.framework */; };
+		78AF6DB8284FD9AA0022EB24 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AF6DB7284FD9AA0022EB24 /* ShareViewController.swift */; };
+		78AF6DBB284FD9AA0022EB24 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 78AF6DB9284FD9AA0022EB24 /* MainInterface.storyboard */; };
+		78AF6DBF284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 78AF6DB5284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		79D02C3280BC519B410D8D12 /* Pods_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621A2487FEB22E135935BFC9 /* Pods_IntegrationTests.framework */; };
 		C8076C07265E10A7006BEC5D /* Pods_shared_AEPOptimizeDemoSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D6DE1D78747B6856E34BE1F /* Pods_shared_AEPOptimizeDemoSwiftUI.framework */; };
 		C8076C08265E10A7006BEC5D /* Pods_shared_AEPOptimizeDemoSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2D6DE1D78747B6856E34BE1F /* Pods_shared_AEPOptimizeDemoSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -82,6 +86,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		78AF6DBD284FD9AA0022EB24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C892B487260EAC74007FE5C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 78AF6DB4284FD9AA0022EB24;
+			remoteInfo = AEPOptimizeDemoAppExtension;
+		};
 		C82A607B2655A67D0062E70A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C892B487260EAC74007FE5C5 /* Project object */;
@@ -120,6 +131,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		78AF6DC3284FD9AA0022EB24 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				78AF6DBF284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C863BF2D2647B573004B90A0 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -137,12 +159,19 @@
 /* Begin PBXFileReference section */
 		07661FE6B8A8FEDCE0658626 /* Pods-shared-AEPOptimizeDemoObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoObjC.release.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoObjC/Pods-shared-AEPOptimizeDemoObjC.release.xcconfig"; sourceTree = "<group>"; };
 		2D6DE1D78747B6856E34BE1F /* Pods_shared_AEPOptimizeDemoSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_shared_AEPOptimizeDemoSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BEAC61A7614146CFE6ADBA3 /* Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoAppExtension/Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		621A2487FEB22E135935BFC9 /* Pods_IntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6EA826BD338B1E31A687FBE2 /* Pods-shared-AEPOptimizeDemoAppExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoAppExtension.release.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoAppExtension/Pods-shared-AEPOptimizeDemoAppExtension.release.xcconfig"; sourceTree = "<group>"; };
 		7286C657388C58CF68762296 /* Pods-AEPOptimize.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPOptimize.release.xcconfig"; path = "Target Support Files/Pods-AEPOptimize/Pods-AEPOptimize.release.xcconfig"; sourceTree = "<group>"; };
 		74B9C2F3CA52295A7E3D1705 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78AF6DB5284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = AEPOptimizeDemoAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		78AF6DB7284FD9AA0022EB24 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		78AF6DBA284FD9AA0022EB24 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		78AF6DBC284FD9AA0022EB24 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83B41C5C36AC2A19E05B09BF /* Pods-shared-AEPOptimizeDemoSwiftUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoSwiftUI.release.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoSwiftUI/Pods-shared-AEPOptimizeDemoSwiftUI.release.xcconfig"; sourceTree = "<group>"; };
 		83FC35562E7450747904E39C /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		906767562397250C4323720D /* Pods_AEPEdgePersonalizationDemoSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPEdgePersonalizationDemoSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9756675167E8274119439EC8 /* Pods_shared_AEPOptimizeDemoAppExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_shared_AEPOptimizeDemoAppExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9EE07424FC1DD074D8B9FD0C /* Pods_FunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A639DAFB13BE14F6D31F42AD /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		B48C275D1BA731A0183926FC /* Pods-shared-AEPOptimizeDemoObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoObjC.debug.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoObjC/Pods-shared-AEPOptimizeDemoObjC.debug.xcconfig"; sourceTree = "<group>"; };
@@ -229,6 +258,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		78AF6DB2284FD9AA0022EB24 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25A7F16F9547EE83F5734E3C /* Pods_shared_AEPOptimizeDemoAppExtension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C82A605B2655A6480062E70A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -285,6 +322,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		78AF6DB6284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension */ = {
+			isa = PBXGroup;
+			children = (
+				78AF6DB7284FD9AA0022EB24 /* ShareViewController.swift */,
+				78AF6DB9284FD9AA0022EB24 /* MainInterface.storyboard */,
+				78AF6DBC284FD9AA0022EB24 /* Info.plist */,
+			);
+			path = AEPOptimizeDemoAppExtension;
+			sourceTree = "<group>";
+		};
 		BB536604A8DD76C8A52A52E4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -294,6 +341,7 @@
 				E9AEC9FCA4936B233E489076 /* Pods_shared_AEPOptimizeDemoObjC.framework */,
 				2D6DE1D78747B6856E34BE1F /* Pods_shared_AEPOptimizeDemoSwiftUI.framework */,
 				621A2487FEB22E135935BFC9 /* Pods_IntegrationTests.framework */,
+				9756675167E8274119439EC8 /* Pods_shared_AEPOptimizeDemoAppExtension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -313,6 +361,8 @@
 				83B41C5C36AC2A19E05B09BF /* Pods-shared-AEPOptimizeDemoSwiftUI.release.xcconfig */,
 				EB1D98B023EDA0CAEEC67ACF /* Pods-IntegrationTests.debug.xcconfig */,
 				A639DAFB13BE14F6D31F42AD /* Pods-IntegrationTests.release.xcconfig */,
+				3BEAC61A7614146CFE6ADBA3 /* Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig */,
+				6EA826BD338B1E31A687FBE2 /* Pods-shared-AEPOptimizeDemoAppExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -346,6 +396,7 @@
 		C863BE7A26458225004B90A0 /* TestApps */ = {
 			isa = PBXGroup;
 			children = (
+				78AF6DB6284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension */,
 				C863BE9B26458371004B90A0 /* AEPOptimizeDemoSwiftUI */,
 				C82A603E2655A6300062E70A /* AEPOptimizeDemoObjC */,
 			);
@@ -513,6 +564,7 @@
 				C863BE9A26458371004B90A0 /* AEPOptimizeDemoSwiftUI.app */,
 				C82A605E2655A6480062E70A /* AEPOptimizeDemoObjC.app */,
 				C8D4B30426A696E300E48629 /* IntegrationTests.xctest */,
+				78AF6DB5284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -572,6 +624,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		78AF6DB4284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 78AF6DC0284FD9AA0022EB24 /* Build configuration list for PBXNativeTarget "AEPOptimizeDemoAppExtension" */;
+			buildPhases = (
+				08049C42BF0B4A33A975A8F5 /* [CP] Check Pods Manifest.lock */,
+				78AF6DB1284FD9AA0022EB24 /* Sources */,
+				78AF6DB2284FD9AA0022EB24 /* Frameworks */,
+				78AF6DB3284FD9AA0022EB24 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AEPOptimizeDemoAppExtension;
+			productName = AEPOptimizeDemoAppExtension;
+			productReference = 78AF6DB5284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		C82A605D2655A6480062E70A /* AEPOptimizeDemoObjC */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C82A60742655A64A0062E70A /* Build configuration list for PBXNativeTarget "AEPOptimizeDemoObjC" */;
@@ -602,11 +672,13 @@
 				C863BE9826458371004B90A0 /* Resources */,
 				ECD436B3D15041B61C264695 /* [CP] Embed Pods Frameworks */,
 				C863BF2D2647B573004B90A0 /* Embed Frameworks */,
+				78AF6DC3284FD9AA0022EB24 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				C863BF2A2647B53D004B90A0 /* PBXTargetDependency */,
+				78AF6DBE284FD9AA0022EB24 /* PBXTargetDependency */,
 			);
 			name = AEPOptimizeDemoSwiftUI;
 			productName = AEPEdgePersonalizationDemoSwiftUI;
@@ -699,9 +771,12 @@
 		C892B487260EAC74007FE5C5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1230;
 				TargetAttributes = {
+					78AF6DB4284FD9AA0022EB24 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					C82A605D2655A6480062E70A = {
 						CreatedOnToolsVersion = 12.3;
 					};
@@ -743,11 +818,20 @@
 				C8D4B30326A696E300E48629 /* IntegrationTests */,
 				C863BE9926458371004B90A0 /* AEPOptimizeDemoSwiftUI */,
 				C82A605D2655A6480062E70A /* AEPOptimizeDemoObjC */,
+				78AF6DB4284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		78AF6DB3284FD9AA0022EB24 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78AF6DBB284FD9AA0022EB24 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C82A605C2655A6480062E70A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -798,6 +882,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		08049C42BF0B4A33A975A8F5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-shared-AEPOptimizeDemoAppExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		086C34A5C89F2039F515E81A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1035,6 +1141,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		78AF6DB1284FD9AA0022EB24 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78AF6DB8284FD9AA0022EB24 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C82A605A2655A6480062E70A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1133,6 +1247,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		78AF6DBE284FD9AA0022EB24 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 78AF6DB4284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension */;
+			targetProxy = 78AF6DBD284FD9AA0022EB24 /* PBXContainerItemProxy */;
+		};
 		C82A607C2655A67D0062E70A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C892B48F260EAC74007FE5C5 /* AEPOptimize */;
@@ -1161,6 +1280,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		78AF6DB9284FD9AA0022EB24 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				78AF6DBA284FD9AA0022EB24 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		C82A60432655A6300062E70A /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1180,6 +1307,62 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		78AF6DC1284FD9AA0022EB24 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3BEAC61A7614146CFE6ADBA3 /* Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FKGEE875K4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AEPOptimizeDemoAppExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = AEPOptimizeDemoAppExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPOptimizeDemoSwiftUI.AEPOptimizeDemoAppExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		78AF6DC2284FD9AA0022EB24 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6EA826BD338B1E31A687FBE2 /* Pods-shared-AEPOptimizeDemoAppExtension.release.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FKGEE875K4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = AEPOptimizeDemoAppExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = AEPOptimizeDemoAppExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPOptimizeDemoSwiftUI.AEPOptimizeDemoAppExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		C82A60752655A64A0062E70A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B48C275D1BA731A0183926FC /* Pods-shared-AEPOptimizeDemoObjC.debug.xcconfig */;
@@ -1224,6 +1407,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAEFFD565F7D61D1A677746B /* Pods-shared-AEPOptimizeDemoSwiftUI.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -1247,6 +1431,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 83B41C5C36AC2A19E05B09BF /* Pods-shared-AEPOptimizeDemoSwiftUI.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -1432,6 +1617,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9F5444B59B60883FB4F020C /* Pods-AEPOptimize.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -1462,6 +1648,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7286C657388C58CF68762296 /* Pods-AEPOptimize.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -1575,6 +1762,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		78AF6DC0284FD9AA0022EB24 /* Build configuration list for PBXNativeTarget "AEPOptimizeDemoAppExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				78AF6DC1284FD9AA0022EB24 /* Debug */,
+				78AF6DC2284FD9AA0022EB24 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C82A60742655A64A0062E70A /* Build configuration list for PBXNativeTarget "AEPOptimizeDemoObjC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AEPOptimize.xcodeproj/xcshareddata/xcschemes/AEPOptimizeDemoAppExtension.xcscheme
+++ b/AEPOptimize.xcodeproj/xcshareddata/xcschemes/AEPOptimizeDemoAppExtension.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "78AF6D9E284FCA9D0022EB24"
+               BuildableName = "AEPOptimizeDemoAppExtension.appex"
+               BlueprintName = "AEPOptimizeDemoAppExtension"
+               ReferencedContainer = "container:AEPOptimize.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C863BE9926458371004B90A0"
+               BuildableName = "AEPOptimizeDemoSwiftUI.app"
+               BlueprintName = "AEPOptimizeDemoSwiftUI"
+               ReferencedContainer = "container:AEPOptimize.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "1"
+         BundleIdentifier = "com.apple.mobilesafari"
+         RemotePath = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications/MobileSafari.app">
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C863BE9926458371004B90A0"
+            BuildableName = "AEPOptimizeDemoSwiftUI.app"
+            BlueprintName = "AEPOptimizeDemoSwiftUI"
+            ReferencedContainer = "container:AEPOptimize.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C863BE9926458371004B90A0"
+            BuildableName = "AEPOptimizeDemoSwiftUI.app"
+            BlueprintName = "AEPOptimizeDemoSwiftUI"
+            ReferencedContainer = "container:AEPOptimize.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Podfile
+++ b/Podfile
@@ -28,17 +28,29 @@ target 'IntegrationTests' do
   pod 'AEPIdentity'
 end
 
-abstract_target 'shared' do
+def shared_app
+  pod 'AEPSignal'
+  pod 'AEPAssurance'
+end
+
+def shared_all
   pod 'AEPCore'
   pod 'AEPLifecycle'
   pod 'AEPIdentity'
-  pod 'AEPSignal'
   pod 'AEPEdge'
   pod 'AEPEdgeConsent'
   pod 'AEPEdgeIdentity'
-  pod 'AEPAssurance'
+end
 
-  target 'AEPOptimizeDemoSwiftUI'
-  target 'AEPOptimizeDemoObjC'
+
+abstract_target 'shared' do
+  shared_all
+  target 'AEPOptimizeDemoAppExtension'
+  target 'AEPOptimizeDemoSwiftUI' do
+    shared_app
+  end
+  target 'AEPOptimizeDemoObjC' do
+    shared_app
+  end
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - AEPCore (3.6.0):
     - AEPRulesEngine (>= 1.1.0)
     - AEPServices (>= 3.6.0)
-  - AEPEdge (1.4.0):
+  - AEPEdge (1.4.1):
     - AEPCore (>= 3.5.0)
     - AEPEdgeIdentity
   - AEPEdgeConsent (1.0.1):
@@ -17,7 +17,7 @@ PODS:
     - AEPCore (>= 3.6.0)
   - AEPLifecycle (3.6.0):
     - AEPCore (>= 3.6.0)
-  - AEPRulesEngine (1.1.0)
+  - AEPRulesEngine (1.2.0)
   - AEPServices (3.6.0)
   - AEPSignal (3.6.0):
     - AEPCore (>= 3.6.0)
@@ -51,16 +51,16 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
   AEPCore: 03a89f8b792a74e17f739ab535982569d6639b76
-  AEPEdge: 0e7c11d13e71d23d995bff46f48691c1bb65f84f
+  AEPEdge: 6faf60328f9e5ae7a107fd61f9a968f46ebf2928
   AEPEdgeConsent: a23b35ab331d2aa2013fcef49c9d6b80085d5597
   AEPEdgeIdentity: 5c42cef81835851232136a9e1fbbbe33b204ee11
   AEPIdentity: bd5c639f2ddb02e2b15f909c661235ccd86bd98a
   AEPLifecycle: 7c0452a650a8ccaaa2473a3625a7004e8687797e
-  AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
+  AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
   AEPServices: fd41aa2d0eda1e6939ae00a99f8431a57d09e1ca
   AEPSignal: bbdb296030fec8239fb316576f40b230267fcf7c
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: f6f726ec88e11f1f1f453e55b14bffaeff570744
+PODFILE CHECKSUM: b483622816a3253c5f2e69bbb8987c110f4e49ba
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.11.2

--- a/TestApps/AEPOptimizeDemoAppExtension/Base.lproj/MainInterface.storyboard
+++ b/TestApps/AEPOptimizeDemoAppExtension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/TestApps/AEPOptimizeDemoAppExtension/Info.plist
+++ b/TestApps/AEPOptimizeDemoAppExtension/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/TestApps/AEPOptimizeDemoAppExtension/ShareViewController.swift
+++ b/TestApps/AEPOptimizeDemoAppExtension/ShareViewController.swift
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+    
+
+import UIKit
+import Social
+import AEPCore
+import AEPIdentity
+import AEPLifecycle
+import AEPEdge
+import AEPEdgeConsent
+import AEPEdgeIdentity
+
+import AEPOptimize
+
+class ShareViewController: SLComposeServiceViewController {
+
+    private let LAUNCH_ENVIRONMENT_FILE_ID = ""
+    private let OVERRIDE_DATASET_ID = ""
+
+    override func presentationAnimationDidFinish() {
+        super.presentationAnimationDidFinish()
+        MobileCore.setLogLevel(.trace)
+
+        MobileCore.registerExtensions([AEPEdgeIdentity.Identity.self, AEPIdentity.Identity.self, Lifecycle.self, Edge.self, Optimize.self]) {
+            MobileCore.configureWith(appId: self.LAUNCH_ENVIRONMENT_FILE_ID)
+
+            // Update Configuration with override dataset identifier
+            MobileCore.updateConfigurationWith(configDict: ["optimize.datasetId": self.OVERRIDE_DATASET_ID])
+        }
+    }
+    override func isContentValid() -> Bool {
+        // Do validation of contentText and/or NSExtensionContext attachments here
+        return true
+    }
+
+    override func didSelectPost() {
+        // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
+    
+        // Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
+        self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    override func configurationItems() -> [Any]! {
+        // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
+        return []
+    }
+
+}


### PR DESCRIPTION
[Adds App Extension support to AEPOptimize](#54). Since there are no restricted APIs being used in this extension, this simply turns the "Required-only app-extension safe API" build setting flag on. This will ensure that if any restricted code is used in the future, compile time errors will be shown to be handled appropriately. 

Another test app extension target has been added to the project in order to make sure that the SDK compiles correctly in app extensions.