### PR TITLE
Verify configuration shared state is set before processing proposition requests

### DIFF
--- a/AEPOptimize.podspec
+++ b/AEPOptimize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPOptimize"
-  s.version          = "4.0.0"
+  s.version          = "4.0.1"
   s.summary          = "Experience Platform Optimize extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The Experience Platform Optimize extension provides APIs to enable real-time personalization workflows in the Adobe Experience Platform SDKs using Adobe Target or Adobe Journey Optimizer Offer Decisioning. 

--- a/AEPOptimize.xcodeproj/project.pbxproj
+++ b/AEPOptimize.xcodeproj/project.pbxproj
@@ -1641,7 +1641,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPOptimize;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1671,7 +1671,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPOptimize;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - AEPCore (4.0.0):
     - AEPRulesEngine (>= 4.0.0)
     - AEPServices (>= 4.0.0)
-  - AEPEdge (4.0.0):
+  - AEPEdge (4.1.0):
     - AEPCore (>= 4.0.0)
     - AEPEdgeIdentity (>= 4.0.0)
   - AEPEdgeConsent (4.0.0):
@@ -51,7 +51,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AEPAssurance: 4fa3138ddd7308c1f9923570f4d2b0b8526a916f
   AEPCore: dd7cd69696c768c610e6adc0307032985a381c7e
-  AEPEdge: ffea1ada1e81c9cb239aac694efa5c8635b50c1f
+  AEPEdge: 684a60362d17349fab5da48d6e4f965849ed9ad2
   AEPEdgeConsent: 54c1b6a30a3d646e3d4bc4bae1713755422b471e
   AEPEdgeIdentity: c2396b9119abd6eb530ea11efc58ec019b163bd4
   AEPIdentity: 45ee1c3717e08ff3ca60930caf4a869d60d7bf08

--- a/Sources/AEPOptimize/Array+Optimize.swift
+++ b/Sources/AEPOptimize/Array+Optimize.swift
@@ -19,7 +19,7 @@ extension Array {
         var dictionary = [Key: Element]()
 
         for element in self {
-            dictionary[try transform(element)] = element
+            try dictionary[transform(element)] = element
         }
         return dictionary
     }

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -88,7 +88,7 @@ public class Optimize: NSObject, Extension {
 
     public func readyForEvent(_ event: Event) -> Bool {
         if event.source == EventSource.requestContent {
-            return getSharedState(extensionName: OptimizeConstants.Configuration.EXTENSION_NAME, event: event)?.value != nil
+            return getSharedState(extensionName: OptimizeConstants.Configuration.EXTENSION_NAME, event: event)?.status == .set
         }
         return true
     }

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -13,7 +13,7 @@
 enum OptimizeConstants {
     static let EXTENSION_NAME = "com.adobe.optimize"
     static let FRIENDLY_NAME = "Optimize"
-    static let EXTENSION_VERSION = "4.0.0"
+    static let EXTENSION_VERSION = "4.0.1"
     static let LOG_TAG = FRIENDLY_NAME
 
     static let DECISION_SCOPE_NAME = "name"

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -67,6 +67,55 @@ class OptimizeFunctionalTests: XCTestCase {
         // verify
         XCTAssertTrue(result)
     }
+    
+    func testReadyForEvent_configPending() {
+        // setup
+        let testEvent = Event(name: "Optimize Update Propositions Request",
+                              type: "com.adobe.eventType.optimize",
+                              source: "com.adobe.eventSource.requestContent",
+                              data: [
+                                "requesttype": "updatepropositions",
+                                "decisionscopes": [
+                                    [
+                                        "name": "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ=="
+                                    ]
+                                ]
+                              ])
+
+        mockRuntime.simulateSharedState(for: ("com.adobe.module.configuration"),
+                                        data: ([
+                                            "edge.configId": "ffffffff-ffff-ffff-ffff-ffffffffffff"] as [String: Any], .pending))
+
+        // test
+        let result = optimize.readyForEvent(testEvent)
+
+        // verify
+        XCTAssertFalse(result)
+    }
+    
+    func testReadyForEvent_configPendingNoData() {
+        // setup
+        let testEvent = Event(name: "Optimize Update Propositions Request",
+                              type: "com.adobe.eventType.optimize",
+                              source: "com.adobe.eventSource.requestContent",
+                              data: [
+                                "requesttype": "updatepropositions",
+                                "decisionscopes": [
+                                    [
+                                        "name": "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ=="
+                                    ]
+                                ]
+                              ])
+
+        mockRuntime.simulateSharedState(for: ("com.adobe.module.configuration"),
+                                        data: (nil, .pending))
+
+        // test
+        let result = optimize.readyForEvent(testEvent)
+
+        // verify
+        XCTAssertFalse(result)
+    }
 
     func testReadyForEvent_configNotAvailable() {
         // setup
@@ -83,7 +132,7 @@ class OptimizeFunctionalTests: XCTestCase {
                               ])
 
         mockRuntime.simulateSharedState(for: ("com.adobe.module.configuration"),
-                                        data: (nil, .pending))
+                                        data: (nil, .none))
 
         // test
         let result = optimize.readyForEvent(testEvent)


### PR DESCRIPTION
* Verify configuration shared state is set before processing proposition requests.

* Fixed warning: (hoistTry) Moving inline try to start of expression.

* Updated podspec

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
