### PR TITLE
MOB-20804 - updateProposition api with a callback to handle timeout

### DIFF
--- a/AEPOptimize.xcodeproj/project.pbxproj
+++ b/AEPOptimize.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		78AF6DBB284FD9AA0022EB24 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 78AF6DB9284FD9AA0022EB24 /* MainInterface.storyboard */; };
 		78AF6DBF284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 78AF6DB5284FD9AA0022EB24 /* AEPOptimizeDemoAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		79AF0BBA3B4B3F0D2B46C847 /* Pods_AEPOptimize.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89FA9F1584C29AFB176C28B9 /* Pods_AEPOptimize.framework */; };
+		B6B401C52C8052210082B3FE /* OptimizeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B401C42C8052210082B3FE /* OptimizeError.swift */; };
 		C8076C4D265EE786006BEC5D /* TargetProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8076C3F265EE768006BEC5D /* TargetProduct.swift */; };
 		C8076C52265EE789006BEC5D /* TargetOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8076C46265EE776006BEC5D /* TargetOrder.swift */; };
 		C8076C57265EE78E006BEC5D /* DictionaryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8076C45265EE776006BEC5D /* DictionaryRowView.swift */; };
@@ -187,6 +188,7 @@
 		AB699BC71E1531AB6A02B9AD /* Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig"; path = "Target Support Files/Pods-shared-AEPOptimizeDemoAppExtension/Pods-shared-AEPOptimizeDemoAppExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		AB8BAF0E948D2E2747418C4E /* Pods-FunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B588A06BD3941420A1C1CBC5 /* Pods-AEPOptimizeDemoObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPOptimizeDemoObjC.debug.xcconfig"; path = "Target Support Files/Pods-AEPOptimizeDemoObjC/Pods-AEPOptimizeDemoObjC.debug.xcconfig"; sourceTree = "<group>"; };
+		B6B401C42C8052210082B3FE /* OptimizeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizeError.swift; sourceTree = "<group>"; };
 		BEA1EA2DAE5E666C7DEEA655 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C2AB724370848D9EA2ABD4AA /* Pods-AEPOptimizeDemoAppExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPOptimizeDemoAppExtension.release.xcconfig"; path = "Target Support Files/Pods-AEPOptimizeDemoAppExtension/Pods-AEPOptimizeDemoAppExtension.release.xcconfig"; sourceTree = "<group>"; };
 		C592630F611720CFBE4F0009 /* Pods_AEPOptimizeDemoObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPOptimizeDemoObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -517,6 +519,7 @@
 				C88C5F1126152DAB003AE3DE /* DecisionScope.swift */,
 				C88C5EDC2614F640003AE3DE /* Offer.swift */,
 				C8DE6B692684181A0076623F /* Offer+Tracking.swift */,
+				B6B401C42C8052210082B3FE /* OptimizeError.swift */,
 				C88C5EE02614F693003AE3DE /* OfferType.swift */,
 				C88C5F0D26152CFF003AE3DE /* OptimizeProposition.swift */,
 				C8DE6BEE2686848A0076623F /* Proposition+Tracking.swift */,
@@ -1224,6 +1227,7 @@
 				C88C5F0E26152CFF003AE3DE /* OptimizeProposition.swift in Sources */,
 				C88C5F1226152DAB003AE3DE /* DecisionScope.swift in Sources */,
 				C88C5E952613249C003AE3DE /* OptimizeConstants.swift in Sources */,
+				B6B401C52C8052210082B3FE /* OptimizeError.swift in Sources */,
 				C88C5EE12614F693003AE3DE /* OfferType.swift in Sources */,
 				C88C5F4126187F0B003AE3DE /* String+Optimize.swift in Sources */,
 				C8276BE4261EC74F00508873 /* Array+Optimize.swift in Sources */,

--- a/Sources/AEPOptimize/Event+Optimize.swift
+++ b/Sources/AEPOptimize/Event+Optimize.swift
@@ -65,7 +65,19 @@ extension Event {
                             type: EventType.optimize,
                             source: EventSource.responseContent,
                             data: [
-                                OptimizeConstants.EventDataKeys.RESPONSE_ERROR: error.rawValue
+                                OptimizeConstants.EventDataKeys.RESPONSE_ERROR: error
+                            ])
+    }
+
+    /// Creates a response event with specified AEPOptimizeError type added in the Event data.
+    /// - Parameter error: type of AEPOptimizeError
+    /// - Returns: error response Event
+    func createErrorResponseEvent(_ error: AEPOptimizeError) -> Event {
+        createResponseEvent(name: OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                            type: EventType.optimize,
+                            source: EventSource.responseContent,
+                            data: [
+                                OptimizeConstants.EventDataKeys.RESPONSE_ERROR: error
                             ])
     }
 }

--- a/Sources/AEPOptimize/Event+Optimize.swift
+++ b/Sources/AEPOptimize/Event+Optimize.swift
@@ -57,18 +57,6 @@ extension Event {
         return try? JSONDecoder().decode(T.self, from: jsonData)
     }
 
-    /// Creates a response event with specified AEPError type added in the Event data.
-    /// - Parameter error: type of AEPError
-    /// - Returns: error response Event
-    func createErrorResponseEvent(_ error: AEPError) -> Event {
-        createResponseEvent(name: OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
-                            type: EventType.optimize,
-                            source: EventSource.responseContent,
-                            data: [
-                                OptimizeConstants.EventDataKeys.RESPONSE_ERROR: error
-                            ])
-    }
-
     /// Creates a response event with specified AEPOptimizeError type added in the Event data.
     /// - Parameter error: type of AEPOptimizeError
     /// - Returns: error response Event

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -24,7 +24,7 @@ public extension Optimize {
     /// - Parameter data: Additional free-form data to be sent in the personalization request.
     /// - Parameter completion: Optional completion handler invoked with list of successful decision scopes and errors, if any
     @objc(updatePropositions:withXdm:andData:completion:)
-    static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, _ completion: (([DecisionScope]?, AEPOptimizeError?) -> Void)? = nil) {
+    static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, _ completion: (([DecisionScope: OptimizeProposition]?, AEPOptimizeError?) -> Void)? = nil) {
         let flattenedDecisionScopes = decisionScopes
             .filter { $0.isValid }
             .compactMap { $0.asDictionary() }
@@ -59,15 +59,15 @@ public extension Optimize {
             guard let responseEvent = responseEvent else {
                 let timeoutError = AEPOptimizeError(
                     type: nil,
-                    status: 408,
-                    title: "Request Timeout",
-                    detail: "Update proposition request resulted in a timeout.",
+                    status: OptimizeConstants.ErrorData.Timeout.STATUS,
+                    title: OptimizeConstants.ErrorData.Timeout.TITLE,
+                    detail: OptimizeConstants.ErrorData.Timeout.DETAIL,
                     aepError: AEPError.callbackTimeout
                 )
                 completion?(nil, timeoutError)
                 return
             }
-            let result = responseEvent.data?[OptimizeConstants.EventDataKeys.DECISION_SCOPES] as? [DecisionScope]
+            let result = responseEvent.data?[OptimizeConstants.EventDataKeys.PROPOSITIONS] as? [DecisionScope: OptimizeProposition]
             let error = responseEvent.data?[OptimizeConstants.EventDataKeys.RESPONSE_ERROR] as? AEPOptimizeError
             completion?(result, error)
         }

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -61,7 +61,8 @@ public extension Optimize {
                     status: 408,
                     title: "Request Timeout",
                     detail: "Update proposition request resulted in a timeout.",
-                    aepError: AEPError.callbackTimeout)
+                    aepError: AEPError.callbackTimeout
+                )
                 completion?(nil, timeoutError)
                 return
             }

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -22,6 +22,17 @@ public extension Optimize {
     /// - Parameter decisionScopes: An array of decision scopes.
     /// - Parameter xdm: Additional XDM-formatted data to be sent in the personalization request.
     /// - Parameter data: Additional free-form data to be sent in the personalization request.
+    @objc(updatePropositions:withXdm:andData:)
+    static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil) {
+        updatePropositions(for: decisionScopes, withXdm: xdm, andData: data, nil)
+    }
+
+    /// This API dispatches an Event for the Edge network extension to fetch decision propositions for the provided decision scopes from the decisioning Services enabled behind Experience Edge.
+    ///
+    /// The returned decision propositions are cached in memory in the Optimize SDK extension and can be retrieved using `getPropositions(for:_:)` API.
+    /// - Parameter decisionScopes: An array of decision scopes.
+    /// - Parameter xdm: Additional XDM-formatted data to be sent in the personalization request.
+    /// - Parameter data: Additional free-form data to be sent in the personalization request.
     /// - Parameter completion: Optional completion handler invoked with map of successful decision scopes to propositions and errors, if any
     @objc(updatePropositions:withXdm:andData:completion:)
     static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, _ completion: (([DecisionScope: OptimizeProposition]?, Error?) -> Void)? = nil) {
@@ -32,13 +43,7 @@ public extension Optimize {
         guard !flattenedDecisionScopes.isEmpty else {
             Log.warning(label: OptimizeConstants.LOG_TAG,
                         "Cannot update propositions, provided decision scopes array is empty or has invalid items.")
-            let aepOptimizeError = AEPOptimizeError(
-                type: nil,
-                status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
-                title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
-                detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
-                aepError: AEPError.invalidRequest
-            )
+            let aepOptimizeError = AEPOptimizeError.createAEPOptimizInvalidRequestError()
             completion?(nil, aepOptimizeError)
             return
         }
@@ -64,13 +69,7 @@ public extension Optimize {
                           data: eventData)
         MobileCore.dispatch(event: event, timeout: 10) { responseEvent in
             guard let responseEvent = responseEvent else {
-                let timeoutError = AEPOptimizeError(
-                    type: nil,
-                    status: OptimizeConstants.ErrorData.Timeout.STATUS,
-                    title: OptimizeConstants.ErrorData.Timeout.TITLE,
-                    detail: OptimizeConstants.ErrorData.Timeout.DETAIL,
-                    aepError: AEPError.callbackTimeout
-                )
+                let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError()
                 completion?(nil, timeoutError)
                 return
             }

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -32,6 +32,7 @@ public extension Optimize {
         guard !flattenedDecisionScopes.isEmpty else {
             Log.warning(label: OptimizeConstants.LOG_TAG,
                         "Cannot update propositions, provided decision scopes array is empty or has invalid items.")
+            completion?(nil,nil)
             return
         }
 

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -32,7 +32,7 @@ public extension Optimize {
         guard !flattenedDecisionScopes.isEmpty else {
             Log.warning(label: OptimizeConstants.LOG_TAG,
                         "Cannot update propositions, provided decision scopes array is empty or has invalid items.")
-            completion?(nil,nil)
+            completion?(nil, nil)
             return
         }
 

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -252,9 +252,9 @@ public class Optimize: NSObject, Extension {
                 self.propositionsInProgress.removeAll()
                 let timeoutError = AEPOptimizeError(
                     type: nil,
-                    status: 408,
-                    title: "Request Timeout",
-                    detail: "Update proposition request resulted in a timeout.",
+                    status: OptimizeConstants.ErrorData.Timeout.STATUS,
+                    title: OptimizeConstants.ErrorData.Timeout.TITLE,
+                    detail: OptimizeConstants.ErrorData.Timeout.DETAIL,
                     aepError: AEPError.callbackTimeout
                 )
                 self.dispatch(event: event.createErrorResponseEvent(timeoutError))
@@ -268,7 +268,7 @@ public class Optimize: NSObject, Extension {
                 type: EventType.optimize,
                 source: EventSource.responseContent,
                 data: [
-                    OptimizeConstants.EventDataKeys.DECISION_SCOPES: Array(self.propositionsInProgress.keys)
+                    OptimizeConstants.EventDataKeys.PROPOSITIONS: self.propositionsInProgress
                 ]
             )
             self.dispatch(event: responseEventToSend)

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -255,7 +255,8 @@ public class Optimize: NSObject, Extension {
                     status: 408,
                     title: "Request Timeout",
                     detail: "Update proposition request resulted in a timeout.",
-                    aepError: AEPError.callbackTimeout)
+                    aepError: AEPError.callbackTimeout
+                )
                 self.dispatch(event: event.createErrorResponseEvent(timeoutError))
                 self.eventsQueue.start()
                 return

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -241,19 +241,36 @@ public class Optimize: NSObject, Extension {
         // add the Edge event to update propositions in the events queue.
         eventsQueue.add(edgeEvent)
 
-        // Increase timeout to 5s to ensure edge requests have enough time to complete.
-        MobileCore.dispatch(event: edgeEvent, timeout: 5) { responseEvent in
+        // Increase timeout to 10s to ensure edge requests have enough time to complete.
+        MobileCore.dispatch(event: edgeEvent, timeout: 10) { responseEvent in
             guard
                 let responseEvent = responseEvent,
                 let requestEventId = responseEvent.requestEventId
             else {
-                // response event failed or timed out, remove this event's ID from the requested event IDs dictionary and kick-off queue.
+                // response event failed or timed out, remove this event's ID from the requested event IDs dictionary, dispatch an error response event and kick-off queue.
                 self.updateRequestEventIdsInProgress.removeValue(forKey: edgeEvent.id.uuidString)
                 self.propositionsInProgress.removeAll()
-
+                let timeoutError = AEPOptimizeError(
+                    type: nil,
+                    status: 408,
+                    title: "Request Timeout",
+                    detail: "Update proposition request resulted in a timeout.",
+                    aepError: AEPError.callbackTimeout)
+                self.dispatch(event: event.createErrorResponseEvent(timeoutError))
                 self.eventsQueue.start()
                 return
             }
+
+            // response event to provide success callback to updateProposition public api
+            let responseEventToSend = event.createResponseEvent(
+                name: OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                type: EventType.optimize,
+                source: EventSource.responseContent,
+                data: [
+                    OptimizeConstants.EventDataKeys.DECISION_SCOPES: Array(self.propositionsInProgress.keys)
+                ]
+            )
+            self.dispatch(event: responseEventToSend)
 
             let updateCompleteEvent = responseEvent.createChainedEvent(name: OptimizeConstants.EventNames.OPTIMIZE_UPDATE_COMPLETE,
                                                                        type: EventType.optimize,

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
-
+ 
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -140,7 +140,14 @@ public class Optimize: NSObject, Extension {
                   !eventDecisionScopes.isEmpty
             else {
                 Log.debug(label: OptimizeConstants.LOG_TAG, "Decision scopes, in event data, is either not present or empty.")
-                dispatch(event: event.createErrorResponseEvent(AEPError.invalidRequest))
+                let aepOptimizeError = AEPOptimizeError(
+                    type: nil,
+                    status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
+                    title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
+                    detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
+                    aepError: AEPError.invalidRequest
+                )
+                dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
                 return
             }
             /// Fetch propositions and check if all of the decision scopes are present in the cache
@@ -409,7 +416,14 @@ public class Optimize: NSObject, Extension {
               !decisionScopes.isEmpty
         else {
             Log.debug(label: OptimizeConstants.LOG_TAG, "Decision scopes, in event data, is either not present or empty.")
-            dispatch(event: event.createErrorResponseEvent(AEPError.invalidRequest))
+            let aepOptimizeError = AEPOptimizeError(
+                type: nil,
+                status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
+                title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
+                detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
+                aepError: AEPError.invalidRequest
+            )
+            dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
             return
         }
 

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -3,7 +3,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -140,13 +140,7 @@ public class Optimize: NSObject, Extension {
                   !eventDecisionScopes.isEmpty
             else {
                 Log.debug(label: OptimizeConstants.LOG_TAG, "Decision scopes, in event data, is either not present or empty.")
-                let aepOptimizeError = AEPOptimizeError(
-                    type: nil,
-                    status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
-                    title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
-                    detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
-                    aepError: AEPError.invalidRequest
-                )
+                let aepOptimizeError = AEPOptimizeError.createAEPOptimizInvalidRequestError()
                 dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
                 return
             }
@@ -257,13 +251,7 @@ public class Optimize: NSObject, Extension {
                 // response event failed or timed out, remove this event's ID from the requested event IDs dictionary, dispatch an error response event and kick-off queue.
                 self.updateRequestEventIdsInProgress.removeValue(forKey: edgeEvent.id.uuidString)
                 self.propositionsInProgress.removeAll()
-                let timeoutError = AEPOptimizeError(
-                    type: nil,
-                    status: OptimizeConstants.ErrorData.Timeout.STATUS,
-                    title: OptimizeConstants.ErrorData.Timeout.TITLE,
-                    detail: OptimizeConstants.ErrorData.Timeout.DETAIL,
-                    aepError: AEPError.callbackTimeout
-                )
+                let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError()
                 self.dispatch(event: event.createErrorResponseEvent(timeoutError))
                 self.eventsQueue.start()
                 return
@@ -416,13 +404,7 @@ public class Optimize: NSObject, Extension {
               !decisionScopes.isEmpty
         else {
             Log.debug(label: OptimizeConstants.LOG_TAG, "Decision scopes, in event data, is either not present or empty.")
-            let aepOptimizeError = AEPOptimizeError(
-                type: nil,
-                status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
-                title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
-                detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
-                aepError: AEPError.invalidRequest
-            )
+            let aepOptimizeError = AEPOptimizeError.createAEPOptimizInvalidRequestError()
             dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
             return
         }

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -69,7 +69,10 @@ enum OptimizeConstants {
         static let PAYLOAD = "payload"
         enum ErrorKeys {
             static let TYPE = "type"
+            static let STATUS = "status"
+            static let TITLE = "title"
             static let DETAIL = "detail"
+            static let REPORT = "report"
         }
     }
 
@@ -118,5 +121,13 @@ enum OptimizeConstants {
         static let SCHEMA_OFFER_JSON = "https://ns.adobe.com/experience/offer-management/content-component-json"
         static let SCHEMA_OFFER_IMAGE = "https://ns.adobe.com/experience/offer-management/content-component-imagelink"
         static let SCHEMA_OFFER_TEXT = "https://ns.adobe.com/experience/offer-management/content-component-text"
+    }
+
+    enum ErrorData {
+        enum Timeout {
+            static let STATUS = 408
+            static let TITLE = "Request Timeout"
+            static let DETAIL = "Update/Get proposition request resulted in a timeout."
+        }
     }
 }

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -129,5 +129,11 @@ enum OptimizeConstants {
             static let TITLE = "Request Timeout"
             static let DETAIL = "Update/Get proposition request resulted in a timeout."
         }
+
+        enum InvalidRequest {
+            static let STATUS = 400
+            static let TITLE = "Invalid Request"
+            static let DETAIL = "Decision scopes, in event data, is either not present or empty."
+        }
     }
 }

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -136,4 +136,17 @@ enum OptimizeConstants {
             static let DETAIL = "Decision scopes, in event data, is either not present or empty."
         }
     }
+
+    enum HTTPResponseCodes: Int {
+        case success = 200
+        case noContent = 204
+        case multiStatus = 207
+        case invalidRequest = 400
+        case clientTimeout = 408
+        case tooManyRequests = 429
+        case internalServerError = 500
+        case badGateway = 502
+        case serviceUnavailable = 503
+        case gatewayTimeout = 504
+    }
 }

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -17,11 +17,11 @@ import Foundation
 /// AEPOptimizeError class used to create AEPOptimizeError from error details received from Experience Edge.
 @objc(AEPOptimizeError)
 public class AEPOptimizeError: NSObject {
-    let type: String?
-    let status: Int?
-    let title: String?
-    let detail: String?
-    var aepError = AEPError.none
+    public let type: String?
+    public let status: Int?
+    public let title: String?
+    public let detail: String?
+    public var aepError = AEPError.none
 
     public init(type: String?, status: Int?, title: String?, detail: String?, aepError: AEPError? = nil) {
         self.type = type

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -24,6 +24,17 @@ public class AEPOptimizeError: NSObject, Error {
     public let detail: String?
     public var aepError = AEPError.unexpected
 
+    private let serverErrors = [
+        HTTPResponseCodes.tooManyRequests.rawValue,
+        HTTPResponseCodes.internalServerError.rawValue,
+        HTTPResponseCodes.serviceUnavailable.rawValue
+    ]
+
+    private let networkError = [
+        HTTPResponseCodes.badGateway.rawValue,
+        HTTPResponseCodes.gatewayTimeout.rawValue
+    ]
+
     public init(type: String?, status: Int?, title: String?, detail: String?, aepError: AEPError? = nil) {
         self.type = type
         self.status = status
@@ -38,21 +49,18 @@ public class AEPOptimizeError: NSObject, Error {
             }
             if status == HTTPResponseCodes.clientTimeout.rawValue {
                 self.aepError = .callbackTimeout
-            } else if (400...499).contains(status) && status != HTTPResponseCodes.tooManyRequests.rawValue {
-                self.aepError = .invalidRequest
-            } else if status == HTTPResponseCodes.tooManyRequests.rawValue,
-                      status == HTTPResponseCodes.internalServerError.rawValue,
-                      status == HTTPResponseCodes.serviceUnavailable.rawValue {
+            } else if serverErrors.contains(status) {
                 self.aepError = .serverError
-            } else if status == HTTPResponseCodes.badGateway.rawValue,
-                      status == HTTPResponseCodes.gatewayTimeout.rawValue {
+            } else if networkError.contains(status) {
                 self.aepError = .networkError
+            } else if (400...499).contains(status) {
+                self.aepError = .invalidRequest
             }
         }
     }
 
     static func createAEPOptimizeTimeoutError() -> AEPOptimizeError {
-        return AEPOptimizeError(
+        AEPOptimizeError(
             type: nil,
             status: OptimizeConstants.ErrorData.Timeout.STATUS,
             title: OptimizeConstants.ErrorData.Timeout.TITLE,
@@ -62,7 +70,7 @@ public class AEPOptimizeError: NSObject, Error {
     }
 
     static func createAEPOptimizInvalidRequestError() -> AEPOptimizeError {
-        return AEPOptimizeError(
+        AEPOptimizeError(
             type: nil,
             status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
             title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// AEPOptimizeError class used to create AEPOptimizeError from error details received from Experience Edge.
 @objc(AEPOptimizeError)
-public class AEPOptimizeError: NSObject {
+public class AEPOptimizeError: NSObject, Error {
     public let type: String?
     public let status: Int?
     public let title: String?

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -53,7 +53,7 @@ public class AEPOptimizeError: NSObject, Error {
                 self.aepError = .serverError
             } else if networkError.contains(status) {
                 self.aepError = .networkError
-            } else if (400...499).contains(status) {
+            } else if (400 ... 499).contains(status) {
                 self.aepError = .invalidRequest
             }
         }

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -1,0 +1,39 @@
+// Delete this line
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import AEPCore
+import Foundation
+
+/// AEPOptimizeError class used to create AEPOptimizeError from error details received from Experience Edge.
+@objc(AEPOptimizeError)
+public class AEPOptimizeError: NSObject {
+    let type: String?
+    let status: Int?
+    let title: String?
+    let detail: String?
+    var aepError = AEPError.none
+
+    public init(type: String?, status: Int?, title: String?, detail: String?, aepError: AEPError? = nil) {
+        self.type = type
+        self.status = status
+        self.title = title
+        self.detail = detail
+        if let aepError {
+            self.aepError = aepError
+        } else {
+            if status == 400 {
+                self.aepError = .networkError
+            }
+        }
+    }
+}

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -1,15 +1,15 @@
 // Delete this line
 /*
-Copyright 2024 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
 
 import AEPCore
 import Foundation

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -4,7 +4,7 @@
  This file is licensed to you under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License. You may obtain a copy
  of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software distributed under
  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  OF ANY KIND, either express or implied. See the License for the specific language

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -21,7 +21,7 @@ public class AEPOptimizeError: NSObject {
     public let status: Int?
     public let title: String?
     public let detail: String?
-    public var aepError = AEPError.none
+    public var aepError = AEPError.unexpected
 
     public init(type: String?, status: Int?, title: String?, detail: String?, aepError: AEPError? = nil) {
         self.type = type
@@ -31,7 +31,13 @@ public class AEPOptimizeError: NSObject {
         if let aepError {
             self.aepError = aepError
         } else {
-            if status == 400 {
+            if status == 408 {
+                self.aepError = .callbackTimeout
+            } else if status == 400 || status == 403 || status == 404 {
+                self.aepError = .invalidRequest
+            } else if status == 429 || status == 500 || status == 503 {
+                self.aepError = .serverError
+            } else if status == 502 || status == 504 {
                 self.aepError = .networkError
             }
         }

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -1021,13 +1021,15 @@ class OptimizeFunctionalTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Get propositions request should now dispatch response event after update completion.")
         
         mockRuntime.onEventDispatch = { event in
-            expectation.fulfill()
+            if event.responseID == getEvent.id {
+                expectation.fulfill()
+            }
         }
         
-        wait(for: [expectation], timeout: 10)
-        XCTAssertEqual(mockRuntime.dispatchedEvents.count, 1)
+        wait(for: [expectation], timeout: 12)
+        XCTAssertEqual(mockRuntime.dispatchedEvents.count, 2)
         
-        let dispatchedEvent = mockRuntime.dispatchedEvents.first
+        let dispatchedEvent = mockRuntime.secondEvent
         XCTAssertEqual(dispatchedEvent?.type, "com.adobe.eventType.optimize")
         XCTAssertEqual(dispatchedEvent?.source, "com.adobe.eventSource.responseContent")
 
@@ -1119,7 +1121,9 @@ class OptimizeFunctionalTests: XCTestCase {
 
         let expectationGet = XCTestExpectation(description: "Get event should be queued.")
         mockRuntime.onEventDispatch = { event in
-            expectationGet.fulfill()
+            if event.responseID == getEvent.id {
+                expectationGet.fulfill()
+            }
         }
 
         /// Dispatch the get event Immediately.
@@ -1130,13 +1134,13 @@ class OptimizeFunctionalTests: XCTestCase {
             self?.mockRuntime.simulateComingEvents(optimizeContentComplete)
         })
 
-        wait(for: [expectationGet], timeout: 10)
+        wait(for: [expectationGet], timeout: 12)
         
         /// Verify that the get proposition event was queued & is the last event to be executed.
-        XCTAssertEqual(mockRuntime.firstEvent?.type, "com.adobe.eventType.optimize")
-        XCTAssertEqual(mockRuntime.firstEvent?.source, "com.adobe.eventSource.responseContent")
+        XCTAssertEqual(mockRuntime.secondEvent?.type, "com.adobe.eventType.optimize")
+        XCTAssertEqual(mockRuntime.secondEvent?.source, "com.adobe.eventSource.responseContent")
         
-        guard let propositionsDictionary: [DecisionScope: OptimizeProposition] = mockRuntime.firstEvent?.getTypedData(for: "propositions") else {
+        guard let propositionsDictionary: [DecisionScope: OptimizeProposition] = mockRuntime.secondEvent?.getTypedData(for: "propositions") else {
             XCTFail("Propositions dictionary should be valid.")
             return
         }

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -1397,7 +1397,7 @@ class OptimizeFunctionalTests: XCTestCase {
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
         XCTAssertEqual("com.adobe.eventType.optimize", dispatchedEvent?.type)
         XCTAssertEqual("com.adobe.eventSource.responseContent", dispatchedEvent?.source)
-        XCTAssertEqual(AEPError.invalidRequest, AEPError(rawValue: dispatchedEvent?.data?["responseerror"] as? Int ?? 1000))
+        XCTAssertEqual(AEPError.invalidRequest, dispatchedEvent?.data?["responseerror"] as! AEPError)
         XCTAssertNil(dispatchedEvent?.data?["propositions"])
     }
 

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -1413,9 +1413,10 @@ class OptimizeFunctionalTests: XCTestCase {
         XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
 
         let dispatchedEvent = mockRuntime.dispatchedEvents.first
+        let errorData = dispatchedEvent?.data?["responseerror"] as? AEPOptimizeError
         XCTAssertEqual("com.adobe.eventType.optimize", dispatchedEvent?.type)
         XCTAssertEqual("com.adobe.eventSource.responseContent", dispatchedEvent?.source)
-        XCTAssertEqual(AEPError.invalidRequest, dispatchedEvent?.data?["responseerror"] as! AEPError)
+        XCTAssertEqual(AEPError.invalidRequest, errorData?.aepError)
         XCTAssertNil(dispatchedEvent?.data?["propositions"])
     }
 

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -1029,6 +1029,13 @@ class OptimizeFunctionalTests: XCTestCase {
         wait(for: [expectation], timeout: 12)
         XCTAssertEqual(mockRuntime.dispatchedEvents.count, 2)
         
+        // first event will be a timeout error response event as in functional test we don't recieve response from edge
+        let firstEvent = mockRuntime.firstEvent
+        XCTAssertEqual(firstEvent?.type, "com.adobe.eventType.optimize")
+        XCTAssertEqual(firstEvent?.source, "com.adobe.eventSource.responseContent")
+        XCTAssertNotNil(firstEvent?.data?[OptimizeConstants.EventDataKeys.RESPONSE_ERROR])
+        XCTAssertNil(firstEvent?.data?[OptimizeConstants.EventDataKeys.DECISION_SCOPES])
+        
         let dispatchedEvent = mockRuntime.secondEvent
         XCTAssertEqual(dispatchedEvent?.type, "com.adobe.eventType.optimize")
         XCTAssertEqual(dispatchedEvent?.source, "com.adobe.eventSource.responseContent")
@@ -1135,6 +1142,13 @@ class OptimizeFunctionalTests: XCTestCase {
         })
 
         wait(for: [expectationGet], timeout: 12)
+        
+        // first event will be a timeout error response event as in functional test we don't recieve response from edge
+        let firstEvent = mockRuntime.firstEvent
+        XCTAssertEqual(firstEvent?.type, "com.adobe.eventType.optimize")
+        XCTAssertEqual(firstEvent?.source, "com.adobe.eventSource.responseContent")
+        XCTAssertNotNil(firstEvent?.data?[OptimizeConstants.EventDataKeys.RESPONSE_ERROR])
+        XCTAssertNil(firstEvent?.data?[OptimizeConstants.EventDataKeys.DECISION_SCOPES])
         
         /// Verify that the get proposition event was queued & is the last event to be executed.
         XCTAssertEqual(mockRuntime.secondEvent?.type, "com.adobe.eventType.optimize")

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -100,14 +100,14 @@ class OptimizeIntegrationTests: XCTestCase {
         let exp = expectation(description: "The Update Proposition should result in a time out")
         
         // test
-        Optimize.updatePropositions(for: [decisionScope], withXdm: nil) {scope, error in
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil) {propositions, error in
             // verify
-            XCTAssertNil(scope)
+            XCTAssertNil(propositions)
             XCTAssertNotNil(error)
             XCTAssertTrue(error?.status == 408)
             XCTAssertTrue(error?.aepError == .callbackTimeout)
             XCTAssertTrue(error?.title == "Request Timeout")
-            XCTAssertTrue(error?.detail == "Update proposition request resulted in a timeout.")
+            XCTAssertTrue(error?.detail == "Update/Get proposition request resulted in a timeout.")
             exp.fulfill()
         }
 
@@ -165,8 +165,9 @@ class OptimizeIntegrationTests: XCTestCase {
                                           placementId: "xcore:offer-placement:1111111111111111")
         
         // update propositions
-        Optimize.updatePropositions(for: [decisionScope], withXdm: nil){ (scope,error) in
-            XCTAssertNotNil(scope)
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil){ (propositions,error) in
+            XCTAssertNotNil(propositions)
+            XCTAssertNil(error)
             requestExpectation.fulfill()
         }
 

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -64,13 +64,13 @@ class OptimizeIntegrationTests: XCTestCase {
            "handle":[],\
            "errors":[\
               {\
-                 "type":"EXEG-0201-503",\
+                 "type":"EXEG-0201-408",\
                  "status":408,\
                  "title":"Request timed out. Please try again."\
               }\
            ]\
         }
-        """
+        """ 
 
         // mock edge response
         let requestExpectation = XCTestExpectation(description: "Request for mock service response.")

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -102,12 +102,16 @@ class OptimizeIntegrationTests: XCTestCase {
         // test
         Optimize.updatePropositions(for: [decisionScope], withXdm: nil) {propositions, error in
             // verify
+            guard let error = error as? AEPOptimizeError else {
+                XCTFail("Type mismatch in error received for Update Propositions")
+                return
+            }
             XCTAssertNil(propositions)
             XCTAssertNotNil(error)
-            XCTAssertTrue(error?.status == 408)
-            XCTAssertTrue(error?.aepError == .callbackTimeout)
-            XCTAssertTrue(error?.title == "Request Timeout")
-            XCTAssertTrue(error?.detail == "Update/Get proposition request resulted in a timeout.")
+            XCTAssertTrue(error.status == 408)
+            XCTAssertTrue(error.aepError == .callbackTimeout)
+            XCTAssertTrue(error.title == "Request Timeout")
+            XCTAssertTrue(error.detail == "Update/Get proposition request resulted in a timeout.")
             exp.fulfill()
         }
 

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -105,7 +105,10 @@ class OptimizeIntegrationTests: XCTestCase {
                                           placementId: "xcore:offer-placement:1111111111111111")
         
         // update propositions
-        Optimize.updatePropositions(for: [decisionScope], withXdm: nil)
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil){ (scope,error) in
+            XCTAssertNotNil(scope)
+            requestExpectation.fulfill()
+        }
 
         wait(for: [requestExpectation], timeout: 2)
     }

--- a/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
@@ -117,13 +117,24 @@ class Event_OptimizeTests: XCTestCase {
                               source: "com.adobe.eventSource.requestContent",
                               data: nil)
 
-        let errorResponseEvent = testEvent.createErrorResponseEvent(AEPError.invalidRequest)
+        let aepOptimizeError = AEPOptimizeError(
+            type: nil,
+            status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
+            title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
+            detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
+            aepError: AEPError.invalidRequest
+        )
 
+        let errorResponseEvent = testEvent.createErrorResponseEvent(aepOptimizeError)
+
+        let errorData = errorResponseEvent.data?["responseerror"] as? AEPOptimizeError
         XCTAssertEqual("Optimize Response", errorResponseEvent.name)
         XCTAssertEqual("com.adobe.eventType.optimize", errorResponseEvent.type)
         XCTAssertEqual("com.adobe.eventSource.responseContent", errorResponseEvent.source)
         XCTAssertNotNil(errorResponseEvent.data)
         XCTAssertEqual(1, errorResponseEvent.data?.count)
-        XCTAssertEqual(AEPError.invalidRequest, errorResponseEvent.data?["responseerror"] as! AEPError)
+        XCTAssertEqual(400, errorData?.status)
+        XCTAssertEqual("Invalid Request", errorData?.title)
+        XCTAssertEqual(AEPError.invalidRequest, errorData?.aepError)
     }
 }

--- a/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
@@ -124,6 +124,6 @@ class Event_OptimizeTests: XCTestCase {
         XCTAssertEqual("com.adobe.eventSource.responseContent", errorResponseEvent.source)
         XCTAssertNotNil(errorResponseEvent.data)
         XCTAssertEqual(1, errorResponseEvent.data?.count)
-        XCTAssertEqual(6, errorResponseEvent.data?["responseerror"] as? Int)
+        XCTAssertEqual(AEPError.invalidRequest, errorResponseEvent.data?["responseerror"] as! AEPError)
     }
 }

--- a/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/Event+OptimizeTests.swift
@@ -117,13 +117,7 @@ class Event_OptimizeTests: XCTestCase {
                               source: "com.adobe.eventSource.requestContent",
                               data: nil)
 
-        let aepOptimizeError = AEPOptimizeError(
-            type: nil,
-            status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
-            title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
-            detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
-            aepError: AEPError.invalidRequest
-        )
+        let aepOptimizeError = AEPOptimizeError.createAEPOptimizInvalidRequestError()
 
         let errorResponseEvent = testEvent.createErrorResponseEvent(aepOptimizeError)
 

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -82,11 +82,15 @@ class OptimizePublicAPITests: XCTestCase {
         
         // test
         Optimize.updatePropositions(for: [decisionScope], withXdm: nil) { propositions, error in
-            XCTAssert(error?.status == OptimizeConstants.ErrorData.Timeout.STATUS)
-            XCTAssert(error?.aepError == .callbackTimeout)
-            XCTAssert(error?.title == OptimizeConstants.ErrorData.Timeout.TITLE)
-            XCTAssert(error?.detail == OptimizeConstants.ErrorData.Timeout.DETAIL)
-            XCTAssert(error?.aepError == .callbackTimeout)
+            guard let error = error as? AEPOptimizeError else {
+                XCTFail("Type mismatch in error received for Update Propositions")
+                return
+            }
+            XCTAssert(error.status == OptimizeConstants.ErrorData.Timeout.STATUS)
+            XCTAssert(error.aepError == .callbackTimeout)
+            XCTAssert(error.title == OptimizeConstants.ErrorData.Timeout.TITLE)
+            XCTAssert(error.detail == OptimizeConstants.ErrorData.Timeout.DETAIL)
+            XCTAssert(error.aepError == .callbackTimeout)
             expectation.fulfill()
         }
 

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -72,6 +72,26 @@ class OptimizePublicAPITests: XCTestCase {
         // verify
         wait(for: [expectation], timeout: 1)
     }
+    
+    func testUpdatePropositions_updateTimeout() {
+        // setup
+        let expectation = XCTestExpectation(description: "The Update proposition request should time out.")
+        expectation.assertForOverFulfill = true
+
+        let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
+        
+        // test
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil) { scope, error in
+            XCTAssert(error?.status == 408)
+            XCTAssert(error?.title == "Request Timeout")
+            XCTAssert(error?.detail == "Update proposition request resulted in a timeout.")
+            XCTAssert(error?.aepError == .callbackTimeout)
+            expectation.fulfill()
+        }
+
+        // verify
+        wait(for: [expectation], timeout: 11)
+    }
 
     func testUpdatePropositions_validDecisionScopeWithXdmAndData() {
         // setup

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -81,10 +81,11 @@ class OptimizePublicAPITests: XCTestCase {
         let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
         
         // test
-        Optimize.updatePropositions(for: [decisionScope], withXdm: nil) { scope, error in
-            XCTAssert(error?.status == 408)
-            XCTAssert(error?.title == "Request Timeout")
-            XCTAssert(error?.detail == "Update proposition request resulted in a timeout.")
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil) { propositions, error in
+            XCTAssert(error?.status == OptimizeConstants.ErrorData.Timeout.STATUS)
+            XCTAssert(error?.aepError == .callbackTimeout)
+            XCTAssert(error?.title == OptimizeConstants.ErrorData.Timeout.TITLE)
+            XCTAssert(error?.detail == OptimizeConstants.ErrorData.Timeout.DETAIL)
             XCTAssert(error?.aepError == .callbackTimeout)
             expectation.fulfill()
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR supports update proposition public api call with an optional completion handler invoked with list of successful decision scopes and errors received by edge (if any). In order to provide error details back we have also created a public class AEPOptimizeError and kept an additional field of AEPError in it which is mapped on the basis of error status received.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
