### PR TITLE
[MOB-22281] - Public API Changes with Configurable timeout value for Update/ Get proposition

### DIFF
--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -65,7 +65,6 @@ public extension Optimize {
             OptimizeConstants.EventDataKeys.REQUEST_TYPE: OptimizeConstants.EventDataValues.REQUEST_TYPE_UPDATE,
             OptimizeConstants.EventDataKeys.DECISION_SCOPES: flattenedDecisionScopes
         ]
-
         // Add XDM data
         if let xdm = xdm {
             eventData[OptimizeConstants.EventDataKeys.XDM] = xdm
@@ -74,9 +73,9 @@ public extension Optimize {
         // Add free-form data
         if let data = data {
             eventData[OptimizeConstants.EventDataKeys.DATA] = data
-            eventData[OptimizeConstants.EventDataKeys.TIMEOUT] = timeout
         }
 
+        eventData[OptimizeConstants.EventDataKeys.TIMEOUT] = timeout
         let event = Event(name: OptimizeConstants.EventNames.UPDATE_PROPOSITIONS_REQUEST,
                           type: EventType.optimize,
                           source: EventSource.requestContent,

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -32,23 +32,11 @@ public extension Optimize {
     /// The returned decision propositions are cached in memory in the Optimize SDK extension and can be retrieved using `getPropositions(for:_:)` API.
     /// - Parameter decisionScopes: An array of decision scopes.
     /// - Parameter xdm: Additional XDM-formatted data to be sent in the personalization request.
-    /// - Parameter timeout: Timeout for the event.
-    /// - Parameter data: Additional free-form data to be sent in the personalization request.
-    @objc(updatePropositions:withXdm:andData:timeout:)
-    static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, timeout: TimeInterval) {
-        updatePropositions(for: decisionScopes, withXdm: xdm, andData: data, timeout: timeout, nil)
-    }
-
-    /// This API dispatches an Event for the Edge network extension to fetch decision propositions for the provided decision scopes from the decisioning Services enabled behind Experience Edge.
-    ///
-    /// The returned decision propositions are cached in memory in the Optimize SDK extension and can be retrieved using `getPropositions(for:_:)` API.
-    /// - Parameter decisionScopes: An array of decision scopes.
-    /// - Parameter xdm: Additional XDM-formatted data to be sent in the personalization request.
     /// - Parameter data: Additional free-form data to be sent in the personalization request.
     /// - Parameter completion: Optional completion handler invoked with map of successful decision scopes to propositions and errors, if any
     @objc(updatePropositions:withXdm:andData:completion:)
     static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, _ completion: (([DecisionScope: OptimizeProposition]?, Error?) -> Void)? = nil) {
-        updatePropositions(for: decisionScopes, withXdm: xdm, andData: data, timeout: 10, completion)
+        updatePropositions(for: decisionScopes, withXdm: xdm, andData: data, timeout: OptimizeConstants.DEFAULT_TIMEOUT, completion)
     }
 
     /// This API dispatches an Event for the Edge network extension to fetch decision propositions for the provided decision scopes from the decisioning Services enabled behind Experience Edge.

--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -101,7 +101,7 @@ public extension Optimize {
     ///   - completion: The completion handler to be invoked when the decisions are retrieved from cache.
     @objc(getPropositions:completion:)
     static func getPropositions(for decisionScopes: [DecisionScope], _ completion: @escaping ([DecisionScope: OptimizeProposition]?, Error?) -> Void) {
-        getPropositions(for: decisionScopes, timeout: 10, completion)
+        getPropositions(for: decisionScopes, timeout: OptimizeConstants.DEFAULT_TIMEOUT, completion)
     }
 
     /// This API retrieves the previously fetched decisions for the provided decision scopes from the in-memory extension cache.

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -256,7 +256,7 @@ public class Optimize: NSObject, Extension {
         // add the Edge event to update propositions in the events queue.
         eventsQueue.add(edgeEvent)
 
-        let timeout: TimeInterval = event.data?[OptimizeConstants.EventDataKeys.TIMEOUT] as? TimeInterval ?? 10
+        let timeout: TimeInterval = event.data?[OptimizeConstants.EventDataKeys.TIMEOUT] as? TimeInterval ?? OptimizeConstants.DEFAULT_TIMEOUT
         MobileCore.dispatch(event: edgeEvent, timeout: timeout) { responseEvent in
             guard
                 let responseEvent = responseEvent,

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -256,8 +256,8 @@ public class Optimize: NSObject, Extension {
         // add the Edge event to update propositions in the events queue.
         eventsQueue.add(edgeEvent)
 
-        // Increase timeout to 10s to ensure edge requests have enough time to complete.
-        MobileCore.dispatch(event: edgeEvent, timeout: 10) { responseEvent in
+        let timeout: TimeInterval = event.data?[OptimizeConstants.EventDataKeys.TIMEOUT] as? TimeInterval ?? 10
+        MobileCore.dispatch(event: edgeEvent, timeout: timeout) { responseEvent in
             guard
                 let responseEvent = responseEvent,
                 let requestEventId = responseEvent.requestEventId

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -50,6 +50,7 @@ enum OptimizeConstants {
         static let DECISION_SCOPES = "decisionscopes"
         static let XDM = "xdm"
         static let DATA = "data"
+        static let TIMEOUT = "timeout"
         static let PROPOSITIONS = "propositions"
         static let RESPONSE_ERROR = "responseerror"
         static let PROPOSITION_INTERACTIONS = "propositioninteractions"

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -27,6 +27,7 @@ enum OptimizeConstants {
 
     static let ERROR_UNKNOWN = "unknown"
     static let UNKNOWN_STATUS = 0
+    static let DEFAULT_TIMEOUT: TimeInterval = 10
 
     enum EventNames {
         static let UPDATE_PROPOSITIONS_REQUEST = "Optimize Update Propositions Request"

--- a/TestApps/AEPOptimizeDemoSwiftUI/AEPOptimizeDemoSwiftUIApp.swift
+++ b/TestApps/AEPOptimizeDemoSwiftUI/AEPOptimizeDemoSwiftUIApp.swift
@@ -25,7 +25,7 @@ import AEPOptimize
 import SwiftUI
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
-    private let ENVIRONMENT_FILE_ID = "3149c49c3910/0f12baf27522/launch-0d096c129660-development"
+    private let ENVIRONMENT_FILE_ID = ""
     private let OVERRIDE_DATASET_ID = ""
     
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {

--- a/TestApps/AEPOptimizeDemoSwiftUI/AEPOptimizeDemoSwiftUIApp.swift
+++ b/TestApps/AEPOptimizeDemoSwiftUI/AEPOptimizeDemoSwiftUIApp.swift
@@ -25,7 +25,7 @@ import AEPOptimize
 import SwiftUI
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
-    private let ENVIRONMENT_FILE_ID = ""
+    private let ENVIRONMENT_FILE_ID = "3149c49c3910/0f12baf27522/launch-0d096c129660-development"
     private let OVERRIDE_DATASET_ID = ""
     
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {

--- a/TestApps/AEPOptimizeDemoSwiftUI/OffersView.swift
+++ b/TestApps/AEPOptimizeDemoSwiftUI/OffersView.swift
@@ -160,8 +160,10 @@ struct OffersView: View {
                         htmlDecisionScope,
                         jsonDecisionScope,
                         targetScope
-                    ], withXdm: ["xdmKey": "1234"], andData: data) { data, error in
-                        if let error = error as? AEPOptimizeError {
+                    ], withXdm: ["xdmKey": "1234"], andData: data, timeout: 1
+
+                    ) { data, error in
+                         if let error = error as? AEPOptimizeError {
                             errorAlert = true
                             if let errorStatus = error.status {
                                 errorMessage = (error.title ?? "Unexpected Error") + " : " + String(errorStatus)

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -588,7 +588,50 @@ class OptimizePublicAPITests: XCTestCase {
         // verify
         wait(for: [expectation], timeout: 1)
     }
+    
+    func testUpdatePropositionsWithTimeout() {
+        let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
+    
+        // Setup expectation
+        let expectation = XCTestExpectation(description: "Callback expected.")
+        expectation.assertForOverFulfill = true
+        
+        // Call updatePropositions with a short timeout to simulate timeout scenario
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil, andData: nil, timeout: 1) { propositions, error in
+            // Check for a timeout error scenario
+            guard let error = error as? AEPOptimizeError else {
+                XCTFail("Type mismatch in error received for Update Propositions")
+                return
+            }
+            XCTAssert(error.aepError == .callbackTimeout)
+            XCTAssertNil(propositions)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    
+    func testGetPropositionsWithTimeout() {
+        // Setup test data
+        let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
 
+        let expectation = XCTestExpectation(description: "Callback expected.")
+        expectation.assertForOverFulfill = true
+        
+        Optimize.getPropositions(for: [decisionScope], timeout: 1) { propositions, error in
+            guard let error = error as? AEPError else {
+                XCTFail("Type mismatch in error received for Update Propositions")
+                return
+            }
+            XCTAssert(error == .callbackTimeout)
+            XCTAssertNil(propositions)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
     // MARK: Helper functions
 
     private func registerMockExtension<T: Extension>(_ type: T.Type) {

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -596,9 +596,7 @@ class OptimizePublicAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "Callback expected.")
         expectation.assertForOverFulfill = true
         
-        // Call updatePropositions with a short timeout to simulate timeout scenario
         Optimize.updatePropositions(for: [decisionScope], withXdm: nil, andData: nil, timeout: 1) { propositions, error in
-            // Check for a timeout error scenario
             guard let error = error as? AEPOptimizeError else {
                 XCTFail("Type mismatch in error received for Update Propositions")
                 return

--- a/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/OptimizePublicAPITests.swift
@@ -590,7 +590,7 @@ class OptimizePublicAPITests: XCTestCase {
     }
     
     func testUpdateProposition_responseWithinTimeout() {
-        // setup
+        /// setup
         let propositionB = """
         {
             "id": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
@@ -645,7 +645,7 @@ class OptimizePublicAPITests: XCTestCase {
                                                          type: EventType.edge,
                                                          source: EventSource.requestContent,
                                                          data: eventData)
-                MobileCore.dispatch(event: edgeEvent, timeout: timeout) { responeEvent in
+                MobileCore.dispatch(event: edgeEvent, timeout: timeout) { _ in
                     let responseEvent = event.createResponseEvent(
                         name: "AEP Response Complete",
                         type: EventType.edge,
@@ -655,7 +655,7 @@ class OptimizePublicAPITests: XCTestCase {
                 }
             }
         
-        // Execute
+        /// Execute
         Optimize.updatePropositions(for: [decisionScope], withXdm: nil, andData: nil, timeout: 1) { data, error in
             XCTAssertNil(error)
             XCTAssertNotNil(data)
@@ -684,12 +684,12 @@ class OptimizePublicAPITests: XCTestCase {
             expectation.fulfill()
         }
 
-        // wait
+        /// wait
         wait(for: [expectation], timeout: 2)
     }
     
     func testUpdateProposition_responseExceedsTimeout() {
-        // setup
+        /// setup
         let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
         
         let expectation = XCTestExpectation(description: "updatePropositions should timeout as the response is delayed.")
@@ -720,10 +720,19 @@ class OptimizePublicAPITests: XCTestCase {
                 MobileCore.dispatch(event: edgeEvent)
             }
         
-        // Execute
-        Optimize.updatePropositions(for: [decisionScope], withXdm: nil, andData: nil, timeout: 1) { data, error in
+        /// Execute
+        Optimize.updatePropositions(for: [decisionScope], withXdm: nil, andData: nil, timeout: 1) { data, err in
             XCTAssertNil(data, "Data should be nil when the response times out.")
-            XCTAssertNotNil(error, "An error should be returned when the response times out.")
+            XCTAssertNotNil(err, "An error should be returned when the response times out.")
+            guard let error = err as? AEPOptimizeError else {
+                XCTFail("Type mismatch in error received for Update Propositions")
+                return
+            }
+            XCTAssert(error.status == OptimizeConstants.ErrorData.Timeout.STATUS)
+            XCTAssert(error.aepError == .callbackTimeout)
+            XCTAssert(error.title == OptimizeConstants.ErrorData.Timeout.TITLE)
+            XCTAssert(error.detail == OptimizeConstants.ErrorData.Timeout.DETAIL)
+            XCTAssert(error.aepError == .callbackTimeout)
             expectation.fulfill()
         }
         
@@ -735,25 +744,21 @@ class OptimizePublicAPITests: XCTestCase {
         let propositionB = """
         {
           "id": "AT:example-id",
-          "scope": "optimize-tutorial-loc",
+          "scope": "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==",
           "scopeDetails": {
-            "activity": { "id": "1451350" },
-            "characteristics": { "eventToken": "example-token" }
+            "activity": { "id": "1451350" }
           },
           "items": [
             {
               "id": "0",
-              "data": { "content": "<html>Content</html>" },
-              "meta": { "key": "value" },
-              "schema": "example-schema",
-              "etag": "",
+              "etag": "update",
               "score": 10
             }
           ]
         }
         """.data(using: .utf8)!
         
-        let decisionScope = DecisionScope(name: "optimize-tutorial-loc")
+        let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
         guard let proposition = try? JSONDecoder().decode(OptimizeProposition.self, from: propositionB) else {
             XCTFail("Propositions should be valid.")
             return
@@ -804,12 +809,12 @@ class OptimizePublicAPITests: XCTestCase {
             
             expectation.fulfill()
         }
-        // wait
+        /// wait
         wait(for: [expectation], timeout: 5)
     }
     
     func testGetProposition_responseExceedsTimeout() {
-        // setup
+        /// setup
         let decisionScope = DecisionScope(name: "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==")
         
         let expectation = XCTestExpectation(description: "getPropositions should timeout as the response is delayed.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Added customizable timeout to getPropositions and updatePropositions functions, allowing users to define how long to wait for responses before triggering a timeout error.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
