### PR TITLE
[MOB-22477] - Added Separate cache for Preview Propositions

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
-  - AEPAssurance (5.0.0):
+  - AEPAssurance (5.0.1):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPCore (5.0.0):
+  - AEPCore (5.3.1):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPEdge (5.0.1):
-    - AEPCore (< 6.0.0, >= 5.0.0)
+    - AEPServices (< 6.0.0, >= 5.3.1)
+  - AEPEdge (5.0.3):
+    - AEPCore (< 6.0.0, >= 5.3.1)
     - AEPEdgeIdentity (< 6.0.0, >= 5.0.0)
   - AEPEdgeConsent (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPEdge (< 6.0.0, >= 5.0.0)
   - AEPEdgeIdentity (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
-  - AEPIdentity (5.0.0):
-    - AEPCore (< 6.0.0, >= 5.0.0)
-  - AEPLifecycle (5.0.0):
-    - AEPCore (< 6.0.0, >= 5.0.0)
+  - AEPIdentity (5.3.1):
+    - AEPCore (< 6.0.0, >= 5.3.1)
+  - AEPLifecycle (5.3.1):
+    - AEPCore (< 6.0.0, >= 5.3.1)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.0.0)
-  - AEPSignal (5.0.0):
-    - AEPCore (< 6.0.0, >= 5.0.0)
+  - AEPServices (5.3.1)
+  - AEPSignal (5.3.1):
+    - AEPCore (< 6.0.0, >= 5.3.1)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -51,18 +51,18 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
-  AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
-  AEPEdge: 0873041dfb29f3126260f2dc16d548a1fefbe0c4
+  AEPAssurance: df04baeace42befb0cc213fd6cdfe51651d11ba6
+  AEPCore: 28191f2df03225a5e88b6f8f343f7e18a604c9ef
+  AEPEdge: 105afc7958acd7c016d57f7ac1d6f632bf05e6ee
   AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
   AEPEdgeIdentity: 3161ff33434586962946912d6b8e9e8fca1c4d23
-  AEPIdentity: a65c1eba43a06f01b0dab191b27a53a81adada57
-  AEPLifecycle: d4e0e1e86d6225d87203875d67f56c48f7ab7f67
+  AEPIdentity: 345c9bd3e5f2910148fa46a02dbc89cc5e248196
+  AEPLifecycle: b2c4d928a8556410b8d2ef5763432bc97ebde417
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
-  AEPSignal: b146a3d4e5af51ff588f4f1ffbd40f1541325143
+  AEPServices: fcba979e90f6916b066aa66f016700d7b7534d96
+  AEPSignal: 86e4f8b7f1de33699b3d4b5832535caca0d0d60f
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
 PODFILE CHECKSUM: 6c01a16ccaa4ad210fcb2a0841c0df8d98fd1f78
 
-COCOAPODS: 1.15.0
+COCOAPODS: 1.16.2

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -43,6 +43,7 @@ enum OptimizeConstants {
     enum EventSource {
         static let EDGE_PERSONALIZATION_DECISIONS = "personalization:decisions"
         static let EDGE_ERROR_RESPONSE = "com.adobe.eventSource.errorResponseContent"
+        static let DEBUG = "com.adobe.eventSource.debug"
     }
 
     enum EventDataKeys {

--- a/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
+++ b/Tests/AEPOptimizeTests/FunctionalTests/OptimizeFunctionalTests.swift
@@ -35,7 +35,7 @@ class OptimizeFunctionalTests: XCTestCase {
         // onRegistered() invoked in setUp()
 
         // verify
-        XCTAssertEqual(6, mockRuntime.listeners.count)
+        XCTAssertEqual(7, mockRuntime.listeners.count)
         XCTAssertNotNil(mockRuntime.listeners["com.adobe.eventType.generic.identity-com.adobe.eventSource.requestReset"])
         XCTAssertNotNil(mockRuntime.listeners["com.adobe.eventType.optimize-com.adobe.eventSource.requestReset"])
         XCTAssertNotNil(mockRuntime.listeners["com.adobe.eventType.edge-com.adobe.eventSource.errorResponseContent"])
@@ -2251,4 +2251,54 @@ class OptimizeFunctionalTests: XCTestCase {
         XCTAssertEqual(0, optimize.getUpdateRequestEventIdsInProgress().count)
         XCTAssertEqual(0, optimize.getPropositionsInProgress().count)
     }
+    
+    func testDebugEventTriggeredByExternalSystem(){
+            //setUp
+            let testEvent = Event(name: "AEP Response Event Handle (Spoof)",
+                                  type: "com.adobe.eventType.system",
+                                  source: "com.adobe.eventSource.debug",
+                                  data: [
+                                    "payload": [
+                                      [
+                                          "id": "AT:Spoofed",
+                                          "scope": "optimize-tutorial-loc",
+                                          "scopeDetails": [
+                                              "activity": [
+                                                "id" : "0"
+                                                ],
+                                              "decisionProvider": "TGT"
+                                          ],
+                                          "items": [
+                                              [
+                                                  "id": "xcore:personalized-offer:1111111111111111",
+                                                  "etag": "10",
+                                                  "schema": "https://ns.adobe.com/experience/offer-management/content-component-html",
+                                                  "data": [
+                                                      "id": "xcore:personalized-offer:1111111111111111",
+                                                      "format": "text/html",
+                                                      "content": "<h1>This is HTML content</h1>",
+                                                      "characteristics": [
+                                                          "testing": "true"
+                                                      ]
+                                                  ]
+                                              ]
+                                          ]
+                                      ]
+                                    ],
+                                    "type": "personalization:decisions"
+                                  ])
+
+            // test
+            mockRuntime.simulateComingEvents(testEvent)
+
+            //verify
+            XCTAssertEqual(1, mockRuntime.dispatchedEvents.count)
+
+            let dispatchedEvent = mockRuntime.dispatchedEvents.first
+            XCTAssertEqual("com.adobe.eventType.optimize", dispatchedEvent?.type)
+            XCTAssertEqual("com.adobe.eventSource.notification", dispatchedEvent?.source)
+            
+            XCTAssertEqual(1, optimize.previewCachedPropositions.count)
+            XCTAssertTrue(optimize.cachedPropositions.isEmpty)
+        }
 }


### PR DESCRIPTION
In this PR we've added a separate preview cache and modified handling of get proposition to provide requested data from preview cache if present.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
