### PR TITLE
Added support to provide request Event ID in AEPOptimizeError

### DIFF
--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -83,7 +83,11 @@ public extension Optimize {
                           data: eventData)
         MobileCore.dispatch(event: event, timeout: timeout) { responseEvent in
             guard let responseEvent = responseEvent else {
-                let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError()
+                // Look up the Edge event ID from the mapping (if available)
+                let edgeEventId = Optimize.requestToEdgeEventIds[event.id.uuidString]
+                Optimize.requestToEdgeEventIds.removeValue(forKey: event.id.uuidString)
+                let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError(requestEventId: edgeEventId)
+                debugPrint(timeoutError.requestEventId)
                 completion?(nil, timeoutError)
                 return
             }

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -24,9 +24,9 @@ public class Optimize: NSObject, Extension {
     public let metadata: [String: String]? = nil
     public let runtime: ExtensionRuntime
 
-    // Operation orderer used to maintain the order of update and get propositions events.
-    // It ensures any update propositions requests issued before a get propositions call are completed
-    // and the get propositions request is fulfilled from the latest cached content.
+    /// Operation orderer used to maintain the order of update and get propositions events.
+    /// It ensures any update propositions requests issued before a get propositions call are completed
+    /// and the get propositions request is fulfilled from the latest cached content.
     private let eventsQueue = OperationOrderer<Event>("OptimizeEvents")
 
     /// Dispatch queue used to protect against simultaneous access of our containers from multiple threads
@@ -47,7 +47,7 @@ public class Optimize: NSObject, Extension {
         identifier: "com.adobe.optimize.propositionsInProgress"
     )
 
-    /// Dictionary containing decision propositions currently cached in-memory in the SDK.
+    // Dictionary containing decision propositions currently cached in-memory in the SDK.
     #if DEBUG
         var cachedPropositions = ThreadSafeDictionary<DecisionScope, OptimizeProposition>(identifier: "com.adobe.optimize.cachedPropositions")
     #else
@@ -56,7 +56,7 @@ public class Optimize: NSObject, Extension {
         )
     #endif
 
-    /// Dictionary containing  propositions simulated for preview and cached in-memory in the SDK
+    // Dictionary containing propositions simulated for preview and cached in-memory in the SDK
     #if DEBUG
         var previewCachedPropositions = ThreadSafeDictionary<DecisionScope, OptimizeProposition>(
             identifier: "com.adobe.optimize.previewCachedPropositions"
@@ -178,16 +178,16 @@ public class Optimize: NSObject, Extension {
                     self.dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
                     return
                 }
-                /// Fetch propositions and check if all of the decision scopes are present in the cache
+                // Fetch propositions and check if all of the decision scopes are present in the cache
                 let fetchedPropositions = eventDecisionScopes.filter { self.cachedPropositions.keys.contains($0) }
-                /// Check if the decision scopes are currently in progress in `updateRequestEventIdsInProgress`
+                // Check if the decision scopes are currently in progress in `updateRequestEventIdsInProgress`
                 let scopesInProgress = eventDecisionScopes.filter { scope in
                     self.updateRequestEventIdsInProgress.values.flatMap { $0 }.contains(scope)
                 }
                 if eventDecisionScopes.count == fetchedPropositions.count, scopesInProgress.isEmpty {
                     self.processGetPropositions(event: event)
                 } else {
-                    /// Not all decision scopes are present in the cache or requested scopes are currently in progress, adding it to the event queue
+                    // Not all decision scopes are present in the cache or requested scopes are currently in progress, adding it to the event queue
                     self.eventsQueue.add(event)
                     Log.trace(label: OptimizeConstants.LOG_TAG, "Decision scopes are either not present or currently in progress.")
                 }
@@ -650,12 +650,12 @@ public class Optimize: NSObject, Extension {
     /// - Parameter apiTimeout: The timeout value provided in the API request.
     /// - Returns: The final timeout value to be used.
     private func calculateTimeout(apiTimeout: TimeInterval?) -> TimeInterval {
-        /// Fetch the timeout value from the shared state.
+        // Fetch the timeout value from the shared state.
         if let apiTimeout, apiTimeout != .infinity {
             return apiTimeout
         }
 
-        /// Fetch the timeout value from the shared state only if `apiTimeout` is absent.
+        // Fetch the timeout value from the shared state only if `apiTimeout` is absent.
         var configTimeout: TimeInterval?
         if let sharedState = getSharedState(extensionName: OptimizeConstants.Configuration.EXTENSION_NAME, event: nil)?.value,
            let timeoutValue = sharedState[OptimizeConstants.Configuration.OPTIMIZE_TIMEOUT_VALUE] as? Int
@@ -663,7 +663,7 @@ public class Optimize: NSObject, Extension {
             configTimeout = TimeInterval(timeoutValue)
         }
 
-        /// Return the shared state timeout if available; otherwise, use the default timeout.
+        // Return the shared state timeout if available; otherwise, use the default timeout.
         return configTimeout ?? OptimizeConstants.DEFAULT_TIMEOUT
     }
 

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -67,6 +67,12 @@ public class Optimize: NSObject, Extension {
         )
     #endif
 
+    /// Static dictionary mapping original request event IDs to Edge event IDs.
+    /// This allows the public API to retrieve the Edge event ID even when the extension times out.
+    static var requestToEdgeEventIds = ThreadSafeDictionary<String, String>(
+        identifier: "com.adobe.optimize.requestToEdgeEventIds"
+    )
+
     /// Array containing recoverable network error codes being retried by Edge Network Service
     private let recoverableNetworkErrorCodes: [Int] = [OptimizeConstants.HTTPResponseCodes.clientTimeout.rawValue,
                                                        OptimizeConstants.HTTPResponseCodes.tooManyRequests.rawValue,
@@ -274,6 +280,8 @@ public class Optimize: NSObject, Extension {
             // Storing the request event UUID to compare and process only the anticipated response in the extension.
             self.updateRequestEventIdsInProgress[edgeEvent.id.uuidString] = validDecisionScopes
 
+            // Store mapping from original request event ID to Edge event ID for public API timeout handling
+            Optimize.requestToEdgeEventIds[event.id.uuidString] = edgeEvent.id.uuidString
             // add the Edge event to update propositions in the events queue.
             self.eventsQueue.add(edgeEvent)
 
@@ -287,8 +295,9 @@ public class Optimize: NSObject, Extension {
                     else {
                         // response event failed or timed out, remove this event's ID from the requested event IDs dictionary, dispatch an error response event and kick-off queue.
                         self.updateRequestEventIdsInProgress.removeValue(forKey: edgeEvent.id.uuidString)
+                        Optimize.requestToEdgeEventIds.removeValue(forKey: event.id.uuidString)
                         self.propositionsInProgress.removeAll()
-                        let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError()
+                        let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError(requestEventId: edgeEvent.id.uuidString)
                         self.dispatch(event: event.createErrorResponseEvent(timeoutError))
                         self.eventsQueue.start()
                         return
@@ -313,6 +322,9 @@ public class Optimize: NSObject, Extension {
                         data: responseData
                     )
                     dispatch(event: responseEventToSend)
+
+                    // Clean up request-to-edge event ID mapping after response is dispatched
+                    Optimize.requestToEdgeEventIds.removeValue(forKey: event.id.uuidString)
 
                     let updateCompleteEvent = responseEvent.createChainedEvent(name: OptimizeConstants.EventNames.OPTIMIZE_UPDATE_COMPLETE,
                                                                                type: EventType.optimize,
@@ -481,13 +493,10 @@ public class Optimize: NSObject, Extension {
                                                         status: errorStatus,
                                                         title: errorTitle,
                                                         detail: errorDetail,
-                                                        report: errorReport)
-                guard let edgeEventRequestId = event.requestEventId else {
-                    Log.debug(label: OptimizeConstants.LOG_TAG, "No valid edge event request ID found for error response event.")
-                    return
-                }
+                                                        report: errorReport,
+                                                        requestEventId: requestEventId)
                 // store the error response as an AEPOptimizeError in error dictionary per edge request
-                self.updateRequestEventIdsErrors[edgeEventRequestId] = aepOptimizeError
+                self.updateRequestEventIdsErrors[requestEventId] = aepOptimizeError
             }
         }
     }

--- a/Sources/AEPOptimize/OptimizeError.swift
+++ b/Sources/AEPOptimize/OptimizeError.swift
@@ -24,6 +24,8 @@ public class AEPOptimizeError: NSObject, Error, Codable {
     public let title: String?
     public let detail: String?
     public let report: [String: Any]?
+    /// The Edge request event ID associated with this error. Useful for debugging and investigation.
+    public let requestEventId: String?
     public var aepError = AEPError.unexpected
 
     private let serverErrors = [
@@ -37,12 +39,13 @@ public class AEPOptimizeError: NSObject, Error, Codable {
         HTTPResponseCodes.gatewayTimeout.rawValue
     ]
 
-    public init(type: String?, status: Int?, title: String?, detail: String?, report: [String: Any]?, aepError: AEPError? = nil) {
+    public init(type: String?, status: Int?, title: String?, detail: String?, report: [String: Any]?, aepError: AEPError? = nil, requestEventId: String? = nil) {
         self.type = type
         self.status = status
         self.title = title
         self.detail = detail
         self.report = report
+        self.requestEventId = requestEventId
         if let aepError {
             self.aepError = aepError
         } else {
@@ -62,25 +65,27 @@ public class AEPOptimizeError: NSObject, Error, Codable {
         }
     }
 
-    static func createAEPOptimizeTimeoutError() -> AEPOptimizeError {
+    static func createAEPOptimizeTimeoutError(requestEventId: String? = nil) -> AEPOptimizeError {
         AEPOptimizeError(
             type: nil,
             status: OptimizeConstants.ErrorData.Timeout.STATUS,
             title: OptimizeConstants.ErrorData.Timeout.TITLE,
             detail: OptimizeConstants.ErrorData.Timeout.DETAIL,
             report: nil,
-            aepError: AEPError.callbackTimeout
+            aepError: AEPError.callbackTimeout,
+            requestEventId: requestEventId
         )
     }
 
-    static func createAEPOptimizInvalidRequestError() -> AEPOptimizeError {
+    static func createAEPOptimizInvalidRequestError(requestEventId: String? = nil) -> AEPOptimizeError {
         AEPOptimizeError(
             type: nil,
             status: OptimizeConstants.ErrorData.InvalidRequest.STATUS,
             title: OptimizeConstants.ErrorData.InvalidRequest.TITLE,
             detail: OptimizeConstants.ErrorData.InvalidRequest.DETAIL,
             report: nil,
-            aepError: AEPError.invalidRequest
+            aepError: AEPError.invalidRequest,
+            requestEventId: requestEventId
         )
     }
 
@@ -93,6 +98,7 @@ public class AEPOptimizeError: NSObject, Error, Codable {
         case detail
         case report
         case aepError
+        case requestEventId
     }
 
     public required init(from decoder: Decoder) throws {
@@ -102,6 +108,7 @@ public class AEPOptimizeError: NSObject, Error, Codable {
         status = try container.decodeIfPresent(Int.self, forKey: .status)
         title = try container.decodeIfPresent(String.self, forKey: .title)
         detail = try container.decodeIfPresent(String.self, forKey: .detail)
+        requestEventId = try container.decodeIfPresent(String.self, forKey: .requestEventId)
 
         // Handle [String: Any] using AnyCodable
         let anyCodableReport = try container.decodeIfPresent([String: AnyCodable].self, forKey: .report)
@@ -130,6 +137,7 @@ public class AEPOptimizeError: NSObject, Error, Codable {
         try container.encodeIfPresent(status, forKey: .status)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(detail, forKey: .detail)
+        try container.encodeIfPresent(requestEventId, forKey: .requestEventId)
 
         // Handle [String: Any] using AnyCodable
         try container.encodeIfPresent(AnyCodable.from(dictionary: report), forKey: .report)
@@ -156,6 +164,7 @@ extension AEPOptimizeError: CustomNSError {
         info["detail"] = detail
         info["report"] = report
         info["aepError"] = aepError
+        info["requestEventId"] = requestEventId
         return info
     }
 }

--- a/Sources/AEPOptimize/OptimizeTrackingUtils.swift
+++ b/Sources/AEPOptimize/OptimizeTrackingUtils.swift
@@ -43,7 +43,7 @@ enum OptimizeTrackingUtils {
             OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_INTERACT
         propositionEventType[propEventType] = 1
 
-        let xdmData: [String: Any] = [
+        return [
             OptimizeConstants.JsonKeys.EXPERIENCE_EVENT_TYPE: eventType,
             OptimizeConstants.JsonKeys.EXPERIENCE: [
                 OptimizeConstants.JsonKeys.EXPERIENCE_DECISIONING: [
@@ -52,7 +52,6 @@ enum OptimizeTrackingUtils {
                 ]
             ]
         ]
-        return xdmData
     }
 
     /// Dispatches the track propositions request event with type `EventType.optimize` and source `EventSource.requestContent` and given proposition interactions data.
@@ -88,8 +87,7 @@ enum OptimizeTrackingUtils {
     ///
     /// - Parameter offers: An array of offers to extract propositions from.
     /// - Returns: An array of unique OptimizeProposition objects containing only the relevant offers.
-    /// If no matching propositions are found, returns an empty array.
-
+    ///   If no matching propositions are found, returns an empty array.
     static func mapToUniquePropositions(_ offers: [Offer]) -> [OptimizeProposition] {
         // Get unique propositions from offers
         let uniquePropositions = Set(offers.compactMap { $0.proposition })

--- a/Sources/AEPOptimize/Proposition+Tracking.swift
+++ b/Sources/AEPOptimize/Proposition+Tracking.swift
@@ -24,13 +24,12 @@ public extension OptimizeProposition {
     /// - Note: The returned XDM data does not contain an `eventType` for the Experience Event.
     /// - Returns A dictionary containing XDM data for the propositon reference.
     func generateReferenceXdm() -> [String: Any] {
-        let xdmData: [String: Any] = [
+        [
             OptimizeConstants.JsonKeys.EXPERIENCE: [
                 OptimizeConstants.JsonKeys.EXPERIENCE_DECISIONING: [
                     OptimizeConstants.JsonKeys.DECISIONING_PROPOSITION_ID: id
                 ]
             ]
         ]
-        return xdmData
     }
 }

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -112,6 +112,7 @@ class OptimizeIntegrationTests: XCTestCase {
             XCTAssertTrue(error.aepError == .callbackTimeout)
             XCTAssertTrue(error.title == "Request Timeout")
             XCTAssertTrue(error.detail == "Update/Get proposition request resulted in a timeout.")
+            XCTAssertNotNil(error.requestEventId, "requestEventId should be present in timeout error for debugging")
             exp.fulfill()
         }
 
@@ -515,6 +516,7 @@ class OptimizeIntegrationTests: XCTestCase {
                 XCTAssertTrue(error.aepError == .invalidRequest)
                 XCTAssertTrue(error.title == "Invalid Request")
                 XCTAssertTrue(error.detail == "Request cannot be processed as few parameters are missing. Please check and try again later.")
+                XCTAssertNotNil(error.requestEventId, "requestEventId should be present in Edge error response for debugging")
             }
             invalidResponseExpectation.fulfill()
         }

--- a/Tests/AEPOptimizeTests/UnitTests/AEPOptimizeErrorTests.swift
+++ b/Tests/AEPOptimizeTests/UnitTests/AEPOptimizeErrorTests.swift
@@ -64,4 +64,101 @@ class AEPOptimizeErrorTests: XCTestCase {
         let report = errorUserInfo["report"] as? [String: Any]
         XCTAssertEqual(report?["errorCode"] as? String, "E001")
     }
+    
+    func testAEPOptimizeError_WithRequestEventId() {
+        // Setup
+        let requestEventId = "test-request-event-id-12345"
+        let optimizeError = AEPOptimizeError(
+            type: "timeout-error",
+            status: 408,
+            title: "Request Timeout",
+            detail: "Update proposition request resulted in a timeout.",
+            report: nil,
+            aepError: AEPError.callbackTimeout,
+            requestEventId: requestEventId
+        )
+        
+        // Verify requestEventId is correctly stored
+        XCTAssertEqual(optimizeError.requestEventId, requestEventId)
+        XCTAssertEqual(optimizeError.status, 408)
+        XCTAssertEqual(optimizeError.title, "Request Timeout")
+        XCTAssertEqual(optimizeError.aepError, AEPError.callbackTimeout)
+    }
+    
+    func testAEPOptimizeError_RequestEventIdInErrorUserInfo() {
+        // Setup
+        let requestEventId = "edge-request-uuid-67890"
+        let optimizeError = AEPOptimizeError(
+            type: "edge-error",
+            status: 500,
+            title: "Server Error",
+            detail: "Edge server error",
+            report: nil,
+            aepError: AEPError.serverError,
+            requestEventId: requestEventId
+        )
+        
+        // Verify requestEventId is accessible in errorUserInfo for Objective-C compatibility
+        let errorUserInfo = optimizeError.errorUserInfo
+        XCTAssertEqual(errorUserInfo["requestEventId"] as? String, requestEventId)
+    }
+    
+    func testCreateAEPOptimizeTimeoutError_WithRequestEventId() {
+        // Setup
+        let requestEventId = "timeout-request-id-abc123"
+        
+        // Test
+        let timeoutError = AEPOptimizeError.createAEPOptimizeTimeoutError(requestEventId: requestEventId)
+        
+        // Verify
+        XCTAssertEqual(timeoutError.status, 408)
+        XCTAssertEqual(timeoutError.title, "Request Timeout")
+        XCTAssertEqual(timeoutError.detail, "Update/Get proposition request resulted in a timeout.")
+        XCTAssertEqual(timeoutError.aepError, AEPError.callbackTimeout)
+        XCTAssertEqual(timeoutError.requestEventId, requestEventId)
+    }
+    
+    func testCreateAEPOptimizeInvalidRequestError_WithRequestEventId() {
+        // Setup
+        let requestEventId = "invalid-request-id-xyz789"
+        
+        // Test
+        let invalidRequestError = AEPOptimizeError.createAEPOptimizInvalidRequestError(requestEventId: requestEventId)
+        
+        // Verify
+        XCTAssertEqual(invalidRequestError.status, 400)
+        XCTAssertEqual(invalidRequestError.title, "Invalid Request")
+        XCTAssertEqual(invalidRequestError.detail, "Decision scopes, in event data, is either not present or empty.")
+        XCTAssertEqual(invalidRequestError.aepError, AEPError.invalidRequest)
+        XCTAssertEqual(invalidRequestError.requestEventId, requestEventId)
+    }
+    
+    func testAEPOptimizeError_CodableWithRequestEventId() throws {
+        // Setup
+        let requestEventId = "codable-test-request-id"
+        let originalError = AEPOptimizeError(
+            type: "test-type",
+            status: 400,
+            title: "Test Title",
+            detail: "Test Detail",
+            report: ["key": "value"],
+            aepError: AEPError.invalidRequest,
+            requestEventId: requestEventId
+        )
+        
+        // Encode
+        let encoder = JSONEncoder()
+        let encodedData = try encoder.encode(originalError)
+        
+        // Decode
+        let decoder = JSONDecoder()
+        let decodedError = try decoder.decode(AEPOptimizeError.self, from: encodedData)
+        
+        // Verify all properties including requestEventId survive encode/decode
+        XCTAssertEqual(decodedError.type, originalError.type)
+        XCTAssertEqual(decodedError.status, originalError.status)
+        XCTAssertEqual(decodedError.title, originalError.title)
+        XCTAssertEqual(decodedError.detail, originalError.detail)
+        XCTAssertEqual(decodedError.requestEventId, requestEventId)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds support to provide requestEventId in AEPOptimizeError to the public api of updateProposition api callback. This will have to enable debugging with the upstream service in case of server errors and timeout scenarios for production apps. As of now, we are not able to provide edge request event is in case of error or timeout back to the client and can only be achieved through Assurance or Debug Logs, which customers may not be able to provide for their production apps. 

Reference Jira - https://jira.corp.adobe.com/browse/MOB-24152

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
