### PR TITLE
Updated event type from personalization.request to decisioning.propositionFetch

### DIFF
--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -29,10 +29,10 @@ public class Optimize: NSObject, Extension {
     // and the get propositions request is fulfilled from the latest cached content.
     private let eventsQueue = OperationOrderer<Event>("OptimizeEvents")
 
-    /// Dispatch queue used to protect against simultaneous access of our containers from multiple threads
+    // Dispatch queue used to protect against simultaneous access of our containers from multiple threads
     private let queue: DispatchQueue = .init(label: "com.adobe.optimize.containers.queue")
 
-    /// a dictionary containing the update event IDs and corresponding errors as received from Edge SDK
+    // a dictionary containing the update event IDs and corresponding errors as received from Edge SDK
     private var updateRequestEventIdsErrors = ThreadSafeDictionary<String, AEPOptimizeError>(
         identifier: "com.adobe.optimize.updateRequestEventIdsErrors"
     )
@@ -47,7 +47,7 @@ public class Optimize: NSObject, Extension {
         identifier: "com.adobe.optimize.propositionsInProgress"
     )
 
-    /// Dictionary containing decision propositions currently cached in-memory in the SDK.
+    // Dictionary containing decision propositions currently cached in-memory in the SDK.
     #if DEBUG
         var cachedPropositions = ThreadSafeDictionary<DecisionScope, OptimizeProposition>(identifier: "com.adobe.optimize.cachedPropositions")
     #else
@@ -56,7 +56,7 @@ public class Optimize: NSObject, Extension {
         )
     #endif
 
-    /// Dictionary containing  propositions simulated for preview and cached in-memory in the SDK
+    // Dictionary containing  propositions simulated for preview and cached in-memory in the SDK
     #if DEBUG
         var previewCachedPropositions = ThreadSafeDictionary<DecisionScope, OptimizeProposition>(
             identifier: "com.adobe.optimize.previewCachedPropositions"
@@ -172,16 +172,16 @@ public class Optimize: NSObject, Extension {
                     self.dispatch(event: event.createErrorResponseEvent(aepOptimizeError))
                     return
                 }
-                /// Fetch propositions and check if all of the decision scopes are present in the cache
+                // Fetch propositions and check if all of the decision scopes are present in the cache
                 let fetchedPropositions = eventDecisionScopes.filter { self.cachedPropositions.keys.contains($0) }
-                /// Check if the decision scopes are currently in progress in `updateRequestEventIdsInProgress`
+                // Check if the decision scopes are currently in progress in `updateRequestEventIdsInProgress`
                 let scopesInProgress = eventDecisionScopes.filter { scope in
                     self.updateRequestEventIdsInProgress.values.flatMap { $0 }.contains(scope)
                 }
                 if eventDecisionScopes.count == fetchedPropositions.count, scopesInProgress.isEmpty {
                     self.processGetPropositions(event: event)
                 } else {
-                    /// Not all decision scopes are present in the cache or requested scopes are currently in progress, adding it to the event queue
+                    // Not all decision scopes are present in the cache or requested scopes are currently in progress, adding it to the event queue
                     self.eventsQueue.add(event)
                     Log.trace(label: OptimizeConstants.LOG_TAG, "Decision scopes are either not present or currently in progress.")
                 }
@@ -641,12 +641,12 @@ public class Optimize: NSObject, Extension {
     /// - Parameter apiTimeout: The timeout value provided in the API request.
     /// - Returns: The final timeout value to be used.
     private func calculateTimeout(apiTimeout: TimeInterval?) -> TimeInterval {
-        /// Fetch the timeout value from the shared state.
+        // Fetch the timeout value from the shared state.
         if let apiTimeout, apiTimeout != .infinity {
             return apiTimeout
         }
 
-        /// Fetch the timeout value from the shared state only if `apiTimeout` is absent.
+        // Fetch the timeout value from the shared state only if `apiTimeout` is absent.
         var configTimeout: TimeInterval?
         if let sharedState = getSharedState(extensionName: OptimizeConstants.Configuration.EXTENSION_NAME, event: nil)?.value,
            let timeoutValue = sharedState[OptimizeConstants.Configuration.OPTIMIZE_TIMEOUT_VALUE] as? Int
@@ -654,7 +654,7 @@ public class Optimize: NSObject, Extension {
             configTimeout = TimeInterval(timeoutValue)
         }
 
-        /// Return the shared state timeout if available; otherwise, use the default timeout.
+        // Return the shared state timeout if available; otherwise, use the default timeout.
         return configTimeout ?? OptimizeConstants.DEFAULT_TIMEOUT
     }
 

--- a/Sources/AEPOptimize/Optimize.swift
+++ b/Sources/AEPOptimize/Optimize.swift
@@ -24,15 +24,15 @@ public class Optimize: NSObject, Extension {
     public let metadata: [String: String]? = nil
     public let runtime: ExtensionRuntime
 
-    // Operation orderer used to maintain the order of update and get propositions events.
-    // It ensures any update propositions requests issued before a get propositions call are completed
-    // and the get propositions request is fulfilled from the latest cached content.
+    /// Operation orderer used to maintain the order of update and get propositions events.
+    /// It ensures any update propositions requests issued before a get propositions call are completed
+    /// and the get propositions request is fulfilled from the latest cached content.
     private let eventsQueue = OperationOrderer<Event>("OptimizeEvents")
 
-    // Dispatch queue used to protect against simultaneous access of our containers from multiple threads
+    /// Dispatch queue used to protect against simultaneous access of our containers from multiple threads
     private let queue: DispatchQueue = .init(label: "com.adobe.optimize.containers.queue")
 
-    // a dictionary containing the update event IDs and corresponding errors as received from Edge SDK
+    /// a dictionary containing the update event IDs and corresponding errors as received from Edge SDK
     private var updateRequestEventIdsErrors = ThreadSafeDictionary<String, AEPOptimizeError>(
         identifier: "com.adobe.optimize.updateRequestEventIdsErrors"
     )

--- a/Sources/AEPOptimize/OptimizeConstants.swift
+++ b/Sources/AEPOptimize/OptimizeConstants.swift
@@ -115,7 +115,7 @@ enum OptimizeConstants {
     }
 
     enum JsonValues {
-        static let EE_EVENT_TYPE_PERSONALIZATION = "personalization.request"
+        static let EE_EVENT_TYPE_PERSONALIZATION = "decisioning.propositionFetch"
         static let EE_EVENT_TYPE_PROPOSITION_DISPLAY = "decisioning.propositionDisplay"
         static let EE_EVENT_TYPE_PROPOSITION_INTERACT = "decisioning.propositionInteract"
 

--- a/Sources/AEPOptimize/OptimizeTrackingUtils.swift
+++ b/Sources/AEPOptimize/OptimizeTrackingUtils.swift
@@ -80,16 +80,15 @@ enum OptimizeTrackingUtils {
         MobileCore.dispatch(event: event)
     }
 
-    /// Creates an array of unique propositions containing only offers that match those in the input array.
-    ///
-    /// This function extracts unique propositions from the provided offers and creates new proposition
-    /// objects containing only the relevant offers. This helps ensure tracking only includes data for
-    /// the specific offers that were displayed or interacted with.
-    ///
-    /// - Parameter offers: An array of offers to extract propositions from.
-    /// - Returns: An array of unique OptimizeProposition objects containing only the relevant offers.
-    /// If no matching propositions are found, returns an empty array.
-
+    // Creates an array of unique propositions containing only offers that match those in the input array.
+    //
+    // This function extracts unique propositions from the provided offers and creates new proposition
+    // objects containing only the relevant offers. This helps ensure tracking only includes data for
+    // the specific offers that were displayed or interacted with.
+    //
+    // - Parameter offers: An array of offers to extract propositions from.
+    // - Returns: An array of unique OptimizeProposition objects containing only the relevant offers.
+    // If no matching propositions are found, returns an empty array.
     static func mapToUniquePropositions(_ offers: [Offer]) -> [OptimizeProposition] {
         // Get unique propositions from offers
         let uniquePropositions = Set(offers.compactMap { $0.proposition })

--- a/Sources/AEPOptimize/OptimizeTrackingUtils.swift
+++ b/Sources/AEPOptimize/OptimizeTrackingUtils.swift
@@ -80,15 +80,15 @@ enum OptimizeTrackingUtils {
         MobileCore.dispatch(event: event)
     }
 
-    // Creates an array of unique propositions containing only offers that match those in the input array.
-    //
-    // This function extracts unique propositions from the provided offers and creates new proposition
-    // objects containing only the relevant offers. This helps ensure tracking only includes data for
-    // the specific offers that were displayed or interacted with.
-    //
-    // - Parameter offers: An array of offers to extract propositions from.
-    // - Returns: An array of unique OptimizeProposition objects containing only the relevant offers.
-    // If no matching propositions are found, returns an empty array.
+    /// Creates an array of unique propositions containing only offers that match those in the input array.
+    ///
+    /// This function extracts unique propositions from the provided offers and creates new proposition
+    /// objects containing only the relevant offers. This helps ensure tracking only includes data for
+    /// the specific offers that were displayed or interacted with.
+    ///
+    /// - Parameter offers: An array of offers to extract propositions from.
+    /// - Returns: An array of unique OptimizeProposition objects containing only the relevant offers.
+    /// If no matching propositions are found, returns an empty array.
     static func mapToUniquePropositions(_ offers: [Offer]) -> [OptimizeProposition] {
         // Get unique propositions from offers
         let uniquePropositions = Set(offers.compactMap { $0.proposition })

--- a/Sources/AEPOptimize/Proposition+Tracking.swift
+++ b/Sources/AEPOptimize/Proposition+Tracking.swift
@@ -24,13 +24,12 @@ public extension OptimizeProposition {
     /// - Note: The returned XDM data does not contain an `eventType` for the Experience Event.
     /// - Returns A dictionary containing XDM data for the propositon reference.
     func generateReferenceXdm() -> [String: Any] {
-        let xdmData: [String: Any] = [
+        [
             OptimizeConstants.JsonKeys.EXPERIENCE: [
                 OptimizeConstants.JsonKeys.EXPERIENCE_DECISIONING: [
                     OptimizeConstants.JsonKeys.DECISIONING_PROPOSITION_ID: id
                 ]
             ]
         ]
-        return xdmData
     }
 }

--- a/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
+++ b/Tests/AEPOptimizeTests/IntegrationTests/OptimizeIntegrationTests.swift
@@ -134,7 +134,7 @@ class OptimizeIntegrationTests: XCTestCase {
                     // xdm
                     let xdm = event?["xdm"] as? [String: Any]
                     let eventType = xdm?["eventType"] as? String
-                    XCTAssertEqual("personalization.request", eventType)
+                    XCTAssertEqual("decisioning.propositionFetch", eventType)
                     
                     // query
                     let query = event?["query"] as? [String: Any]


### PR DESCRIPTION
[MOB-24547](https://jira.corp.adobe.com/browse/MOB-24547)
[PLATIR-51299](https://jira.corp.adobe.com/browse/PLATIR-51299)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Desktop and Mobile SDKs are using "personalization.request" to fetch decisions. This is deprecated and should be replaced with "decisioning.propositionFetch".

Table of valid event types:
https://experienceleague.adobe.com/en/docs/experience-platform/xdm/classes/experienceevent

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested AEPOptimize SDK with personalization requests being sent with event type as decisioning.propositionFetch instead of personalization.request. Passed decision scope for both Target and Offer Decisioning and retrieved offers for both. Also compared the Tracking payload sent for Display and Click for corresponding offers. 

Assurance session - https://experience.adobe.com/#/@aemonacpprodcampaign/data-collection/assurance/session/b22ec762-9a8b-4094-bc0e-20fe819c0651/view/event-list
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
