### PR TITLE
Fix ObjC selector parameter order for updatePropositions timeout variant

### DIFF
--- a/Sources/AEPOptimize/Optimize+PublicAPI.swift
+++ b/Sources/AEPOptimize/Optimize+PublicAPI.swift
@@ -48,7 +48,7 @@ public extension Optimize {
     /// - Parameter data: Additional free-form data to be sent in the personalization request.
     /// - Parameter timeout: Timeout for the event.
     /// - Parameter completion: Optional completion handler invoked with map of successful decision scopes to propositions and errors, if any
-    @objc(updatePropositions:withXdm:timeout:andData:completion:)
+    @objc(updatePropositions:withXdm:andData:timeout:completion:)
     static func updatePropositions(for decisionScopes: [DecisionScope], withXdm xdm: [String: Any]?, andData data: [String: Any]? = nil, timeout: TimeInterval, _ completion: (([DecisionScope: OptimizeProposition]?, Error?) -> Void)? = nil) {
         let flattenedDecisionScopes = decisionScopes
             .filter { $0.isValid }


### PR DESCRIPTION
The @objc selector for the timeout overload of updatePropositions had timeout and andData swapped relative to the Swift parameter order, causing ObjC callers to see misleading parameter labels (timeout: expecting NSDictionary, andData: expecting NSTimeInterval).

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
